### PR TITLE
Enable user specification of additional solver options

### DIFF
--- a/examples/MFEM/TEAM/team7.i
+++ b/examples/MFEM/TEAM/team7.i
@@ -79,6 +79,9 @@
   dt = 0.001
   start_time = 0.0
   end_time = 0.02
+
+  l_tol = 1e-16
+  l_max_its = 1000
 []
 
 [Outputs]

--- a/include/problem/MFEMProblem.h
+++ b/include/problem/MFEMProblem.h
@@ -117,8 +117,9 @@ protected:
   hephaestus::Variables _variables;
   hephaestus::AuxKernels _auxkernels;
   hephaestus::Postprocessors _postprocessors;
-  hephaestus::Sources _sources;  
+  hephaestus::Sources _sources;
   hephaestus::InputParameters _exec_params;
+  hephaestus::InputParameters _solver_options;
   hephaestus::Outputs _outputs;
   hephaestus::TransientExecutioner * executioner;
 };

--- a/src/problem/MFEMProblem.C
+++ b/src/problem/MFEMProblem.C
@@ -74,6 +74,13 @@ MFEMProblem::init()
     _exec_params.SetParam("EndTime", float(_moose_executioner->endTime()));
     executioner = new hephaestus::TransientExecutioner(_exec_params);
 
+    EquationSystems & es = FEProblemBase::es();
+    _solver_options.SetParam("Tolerance",
+                             float(es.parameters.get<Real>("linear solver tolerance")));
+    _solver_options.SetParam("MaxIter",
+                             es.parameters.get<unsigned int>("linear solver maximum iterations"));
+    _solver_options.SetParam("PrintLevel", 0);
+
     hephaestus::InputParameters params;
     params.SetParam("Mesh", mfem_parmesh);
     params.SetParam("Executioner", executioner);
@@ -86,6 +93,7 @@ MFEMProblem::init()
     params.SetParam("Sources", _sources);
     params.SetParam("Outputs", _outputs);
     params.SetParam("FormulationName", _formulation);
+    params.SetParam("SolverOptions", _solver_options);
 
     std::cout << "Launching MFEM solve\n\n" << std::endl;
     executioner->Init(params);

--- a/src/problem/MFEMProblem.C
+++ b/src/problem/MFEMProblem.C
@@ -14,6 +14,12 @@ MFEMProblem::validParams()
   params.addParam<int>("order", "Order of the FE variables for MFEM.");
   params.addParam<double>("dt", "Time step");
   params.addParam<double>("end_time", "Time at which to end transient simulation.");
+  params.addParam<int>(
+      "vis_steps",
+      1,
+      "Number of timesteps between successive write outs of data collections to file.");
+  params.addParam<bool>(
+      "use_glvis", false, "Attempt to open GLVis ports to display variables during simulation");
 
   return params;
 }
@@ -72,6 +78,8 @@ MFEMProblem::init()
     _exec_params.SetParam("StartTime", float(_moose_executioner->getStartTime()));
     _exec_params.SetParam("TimeStep", float(dt()));
     _exec_params.SetParam("EndTime", float(_moose_executioner->endTime()));
+    _exec_params.SetParam("VisualisationSteps", getParam<int>("vis_steps"));
+    _exec_params.SetParam("UseGLVis", getParam<bool>("use_glvis"));
     executioner = new hephaestus::TransientExecutioner(_exec_params);
 
     EquationSystems & es = FEProblemBase::es();
@@ -79,7 +87,7 @@ MFEMProblem::init()
                              float(es.parameters.get<Real>("linear solver tolerance")));
     _solver_options.SetParam("MaxIter",
                              es.parameters.get<unsigned int>("linear solver maximum iterations"));
-    _solver_options.SetParam("PrintLevel", 0);
+    _solver_options.SetParam("PrintLevel", -1);
 
     hephaestus::InputParameters params;
     params.SetParam("Mesh", mfem_parmesh);

--- a/src/userobjects/MFEMDivFreeVolumetricSource.C
+++ b/src/userobjects/MFEMDivFreeVolumetricSource.C
@@ -33,10 +33,19 @@ MFEMDivFreeVolumetricSource::MFEMDivFreeVolumetricSource(const InputParameters &
   }
   _restricted_coef = new mfem::PWVectorCoefficient(3, coilsegments, sourcecoefs);
 
+  hephaestus::InputParameters _solver_options;
+  EquationSystems & es = getParam<FEProblemBase *>("_fe_problem_base")->es();
+  _solver_options.SetParam("Tolerance", float(es.parameters.get<Real>("linear solver tolerance")));
+  _solver_options.SetParam("MaxIter",
+                           es.parameters.get<unsigned int>("linear solver maximum iterations"));
+  _solver_options.SetParam("PrintLevel", 0);
+
   hephaestus::InputParameters div_free_source_params;
   div_free_source_params.SetParam("SourceName", source_coef_name);
   div_free_source_params.SetParam("HCurlFESpaceName", std::string("_HCurlFESpace"));
   div_free_source_params.SetParam("H1FESpaceName", std::string("_H1FESpace"));
+  div_free_source_params.SetParam("SolverOptions", _solver_options);
+
   _source = new hephaestus::DivFreeVolumetricSource(div_free_source_params);
 }
 

--- a/src/userobjects/MFEMDivFreeVolumetricSource.C
+++ b/src/userobjects/MFEMDivFreeVolumetricSource.C
@@ -8,6 +8,13 @@ MFEMDivFreeVolumetricSource::validParams()
   InputParameters params = MFEMSource::validParams();
   params.addParam<FunctionName>(
       "function", "The vector function providing the source, to be divergence cleaned.");
+  params.addParam<float>("solver_l_tol",
+                         "Tolerance for the linear solver used when performing divergence "
+                         "cleaning. Defaults to the same value used by the Executioner.");
+  params.addParam<unsigned int>(
+      "solver_max_its",
+      "Maximum number of iterations allowed for the linear solver used when performing divergence "
+      "cleaning. Defaults to the same value used by the Executioner.");
   return params;
 }
 
@@ -35,10 +42,16 @@ MFEMDivFreeVolumetricSource::MFEMDivFreeVolumetricSource(const InputParameters &
 
   hephaestus::InputParameters _solver_options;
   EquationSystems & es = getParam<FEProblemBase *>("_fe_problem_base")->es();
-  _solver_options.SetParam("Tolerance", float(es.parameters.get<Real>("linear solver tolerance")));
-  _solver_options.SetParam("MaxIter",
-                           es.parameters.get<unsigned int>("linear solver maximum iterations"));
-  _solver_options.SetParam("PrintLevel", 0);
+  _solver_options.SetParam("Tolerance",
+                           parameters.isParamSetByUser("solver_l_tol")
+                               ? getParam<float>("solver_l_tol")
+                               : float(es.parameters.get<Real>("linear solver tolerance")));
+  _solver_options.SetParam(
+      "MaxIter",
+      parameters.isParamSetByUser("solver_max_its")
+          ? getParam<unsigned int>("solver_max_its")
+          : es.parameters.get<unsigned int>("linear solver maximum iterations"));
+  _solver_options.SetParam("PrintLevel", -1);
 
   hephaestus::InputParameters div_free_source_params;
   div_free_source_params.SetParam("SourceName", source_coef_name);

--- a/test/tests/integration/eb_thermal/eb_thermal_coupled.i
+++ b/test/tests/integration/eb_thermal/eb_thermal_coupled.i
@@ -124,6 +124,9 @@
   dt = 0.5
   start_time = 0.0
   end_time = 1.0
+  
+  l_tol = 1e-16
+  l_max_its = 1000  
 []
 
 [Outputs]

--- a/test/tests/integration/ebform_rod/rod.i
+++ b/test/tests/integration/ebform_rod/rod.i
@@ -101,6 +101,9 @@
   dt = 0.5
   start_time = 0.0
   end_time = 2.5
+
+  l_tol = 1e-16
+  l_max_its = 1000  
 []
 
 [Outputs]

--- a/test/tests/unit/transfers/elemental_var_coupled.i
+++ b/test/tests/unit/transfers/elemental_var_coupled.i
@@ -80,6 +80,9 @@
   dt = 0.5
   start_time = 0.0
   end_time = 0.5
+  
+  l_tol = 1e-16
+  l_max_its = 1000  
 []
 
 [Outputs]

--- a/test/tests/unit/transfers/fo_nodal_var_coupled.i
+++ b/test/tests/unit/transfers/fo_nodal_var_coupled.i
@@ -60,6 +60,9 @@
   dt = 0.5
   start_time = 0.0
   end_time = 0.5
+
+  l_tol = 1e-16
+  l_max_its = 1000  
 []
 
 [Outputs]


### PR DESCRIPTION
Enables specification of additional solver options (eg. tolerances, max iterations...) by users in the MOOSE executioner block, following a Hephaestus update.