### PR TITLE
Add MFEMPotentialSource

### DIFF
--- a/include/userobjects/MFEMScalarPotentialSource.h
+++ b/include/userobjects/MFEMScalarPotentialSource.h
@@ -1,0 +1,25 @@
+#pragma once
+#include "MFEMSource.h"
+
+class MFEMScalarPotentialSource : public MFEMSource
+{
+public:
+  static InputParameters validParams();
+
+  MFEMScalarPotentialSource(const InputParameters & parameters);
+  virtual ~MFEMScalarPotentialSource();
+
+  virtual void execute() override {}
+  virtual void initialize() override {}
+  virtual void finalize() override {}
+
+  virtual hephaestus::Source * getSource() override;
+  virtual void storeCoefficients(hephaestus::DomainProperties & domain_properties) override;
+
+protected:
+  std::string source_coef_name;
+  std::string potential_name;
+  std::string conductivity_coef_name;
+
+  mfem::PWVectorCoefficient * _restricted_coef;
+};

--- a/src/userobjects/MFEMScalarPotentialSource.C
+++ b/src/userobjects/MFEMScalarPotentialSource.C
@@ -1,0 +1,69 @@
+#include "MFEMScalarPotentialSource.h"
+
+registerMooseObject("ApolloApp", MFEMScalarPotentialSource);
+
+InputParameters
+MFEMScalarPotentialSource::validParams()
+{
+  InputParameters params = MFEMSource::validParams();
+  params.addParam<FunctionName>(
+      "function", "The vector function providing the source, to be divergence cleaned.");
+  params.addParam<float>("solver_l_tol",
+                         "Tolerance for the linear solver used when performing divergence "
+                         "cleaning. Defaults to the same value used by the Executioner.");
+  params.addParam<unsigned int>(
+      "solver_max_its",
+      "Maximum number of iterations allowed for the linear solver used when performing divergence "
+      "cleaning. Defaults to the same value used by the Executioner.");
+  params.addRequiredParam<std::string>(
+      "potential",
+      "Name of the potential used in the solver, necessary to find boundary conditions");
+  params.addRequiredParam<std::string>(
+      "conductivity", "Name of the conductivity coefficient associated with the potential.");
+
+  return params;
+}
+
+MFEMScalarPotentialSource::MFEMScalarPotentialSource(const InputParameters & parameters)
+  : MFEMSource(parameters),
+    source_coef_name(std::string("source_") + getParam<std::string>("_object_name")),
+    potential_name(getParam<std::string>("potential")),
+    conductivity_coef_name(getParam<std::string>("conductivity"))
+{
+  hephaestus::InputParameters _solver_options;
+  EquationSystems & es = getParam<FEProblemBase *>("_fe_problem_base")->es();
+  _solver_options.SetParam("Tolerance",
+                           parameters.isParamSetByUser("solver_l_tol")
+                               ? getParam<float>("solver_l_tol")
+                               : float(es.parameters.get<Real>("linear solver tolerance")));
+  _solver_options.SetParam(
+      "MaxIter",
+      parameters.isParamSetByUser("solver_max_its")
+          ? getParam<unsigned int>("solver_max_its")
+          : es.parameters.get<unsigned int>("linear solver maximum iterations"));
+  _solver_options.SetParam("PrintLevel", -1);
+
+  hephaestus::InputParameters scalar_potential_source_params;
+  scalar_potential_source_params.SetParam("SourceName", source_coef_name);
+  scalar_potential_source_params.SetParam("PotentialName", potential_name);
+  scalar_potential_source_params.SetParam("ConductivityCoefName", conductivity_coef_name);
+  scalar_potential_source_params.SetParam("HCurlFESpaceName", std::string("_HCurlFESpace"));
+  scalar_potential_source_params.SetParam("H1FESpaceName", std::string("_H1FESpace"));
+  scalar_potential_source_params.SetParam("SolverOptions", _solver_options);
+
+  _source = new hephaestus::ScalarPotentialSource(scalar_potential_source_params);
+}
+
+hephaestus::Source *
+MFEMScalarPotentialSource::getSource()
+{
+  return _source;
+}
+
+void
+MFEMScalarPotentialSource::storeCoefficients(hephaestus::DomainProperties & domain_properties)
+{
+  // domain_properties.vector_property_map[source_coef_name] = _restricted_coef;
+}
+
+MFEMScalarPotentialSource::~MFEMScalarPotentialSource() {}

--- a/test/tests/integration/eb_thermal/eb_thermal_coupled.i
+++ b/test/tests/integration/eb_thermal/eb_thermal_coupled.i
@@ -52,6 +52,14 @@
   [../]
 []
 
+[UserObjects]
+  [./SourcePotential]
+    type = MFEMScalarPotentialSource
+    potential = electric_potential
+    conductivity = electrical_conductivity
+  [../]
+[]
+
 [AuxVariables]
   [temperature]
     family = LAGRANGE


### PR DESCRIPTION
Adds `MFEMPotentialSource` for creating a source term specified by solving an auxiliary potential with boundary conditions and optional conductivity.