### PR TITLE
Create GitHub Action to publish Docker image

### DIFF
--- a/.github/workflows/publishimage.yml
+++ b/.github/workflows/publishimage.yml
@@ -1,0 +1,35 @@
+name: Publish Docker Image
+on:
+  workflow_dispatch:
+  schedule:
+    # Schedule to update image every Monday morning at 04:00.
+    - cron:  '00 4 * * 1'
+  
+jobs:
+  push-docker-image-to-docker-hub:
+    name: DockerPublishUbuntu
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v3
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+        with:
+          images: alexanderianblair/apollo
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+        with:
+          context: docker/apollo-ubuntu/
+          file: docker/apollo-ubuntu/Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
Publishes Docker image of Apollo to DockerHub after build.