### PR TITLE
Edited the overloaded output method in MFEMDataCollection

### DIFF
--- a/include/outputs/MFEMDataCollection.h
+++ b/include/outputs/MFEMDataCollection.h
@@ -14,5 +14,5 @@ public:
   mfem::DataCollection * _data_collection;
 
 protected:
-  virtual void output(const ExecFlagType & type) override{};
+  void output() override{};
 };

--- a/include/outputs/MFEMParaViewDataCollection.h
+++ b/include/outputs/MFEMParaViewDataCollection.h
@@ -16,5 +16,4 @@ protected:
   mfem::ParaViewDataCollection _pv_dc;
   bool _high_order_output;
   unsigned int _refinements;
-  virtual void output(const ExecFlagType & type) override{};
 };

--- a/include/outputs/MFEMVisItDataCollection.h
+++ b/include/outputs/MFEMVisItDataCollection.h
@@ -16,5 +16,4 @@ protected:
   mfem::VisItDataCollection _visit_dc;
   bool _high_order_output;
   unsigned int _refinements;
-  virtual void output(const ExecFlagType & type) override{};
 };


### PR DESCRIPTION
Edited the overloaded output method in "MFEMDataCollection.h". This fixes an issue where the overloaded method did not match the virtual output method defined in "Output.h", resulting in a problem during compilation. 