### PR TITLE
Update base Docker image for apollo-deps and apollo builds

### DIFF
--- a/docker/apollo-deps/Dockerfile
+++ b/docker/apollo-deps/Dockerfile
@@ -1,6 +1,6 @@
 # Build Apollo dependencies
 # Get base image
-FROM alexanderianblair/hephaestus-deps:latest
+FROM alexanderianblair/hephaestus-deps:master
 
 # By default one core is used to compile
 ARG compile_cores=4

--- a/docker/apollo/Dockerfile
+++ b/docker/apollo/Dockerfile
@@ -1,6 +1,6 @@
 # Build and test Apollo image
 # Get base image
-FROM alexanderianblair/apollo-deps:latest
+FROM alexanderianblair/apollo-deps:master
 
 # By default one core is used to compile
 ARG compile_cores=4


### PR DESCRIPTION
Base images for the Docker builds of apollo and apollo-deps were pointing to an outdated build of apollo-deps and hephaestus-deps respectively, rather than the versions rebuilt weekly in the CI. This PR fixes that.