### PR TITLE
EdwardPalmer99/Apollo-Mesh-Transfer-Check-For-Multiple-Element-Types

### DIFF
--- a/src/mesh/CoupledMFEMMesh.C
+++ b/src/mesh/CoupledMFEMMesh.C
@@ -343,7 +343,16 @@ CoupledMFEMMesh::buildElementAndNodeIDs(const std::vector<int> & unique_block_id
     {
       auto element_ptr = *element_iterator;
 
-      int element_id = element_ptr->id();
+      // Each block can contain a different element type but within a block, all
+      // elements must be identical. Check the first element in each block.
+      if (element_iterator == active_block_elements_begin &&
+          element_ptr->n_nodes() != _num_nodes_per_element)
+      {
+        mooseError("Multiple element types detected.");
+        return;
+      }
+
+      const int element_id = element_ptr->id();
 
       std::vector<int> element_node_ids(_num_nodes_per_element);
 

--- a/test/tests/unit/distributed_transfers/tests
+++ b/test/tests/unit/distributed_transfers/tests
@@ -6,6 +6,6 @@
     exodiff = 'elemental_var_coupled_out.e'  
     max_parallel = 2
     min_parallel = 2
-    requirement = 'Apollo shall have the transfer from distributed MOOSE meshes'
+    requirement = 'Apollo shall have ability to transfer distributed MOOSE meshes'
   []  
 []

--- a/test/tests/unit/distributed_transfers/tests
+++ b/test/tests/unit/distributed_transfers/tests
@@ -6,6 +6,6 @@
     exodiff = 'elemental_var_coupled_out.e'  
     max_parallel = 2
     min_parallel = 2
-    requirement = 'Apollo shall have ability to transfer distributed MOOSE meshes'
+    requirement = 'Apollo shall have the ability to transfer distributed MOOSE meshes.'
   []  
 []


### PR DESCRIPTION
Added a safety check in buildElementAndNodeIDs method (file: CoupledMFEMMesh). This checks the first element from each block to ensure that the number of nodes per element is the same. 