### PR TITLE
Revert to using ScalarPotentialSource in coil examples

### DIFF
--- a/examples/MFEM/coil/AFormCoil.i
+++ b/examples/MFEM/coil/AFormCoil.i
@@ -56,20 +56,38 @@
 []
 
 [Functions]
-  [current_magnitude]
+  [potential_high]
     type = ParsedFunction
-    value = cos(2.0*pi*freq*t)
+    value = 1000*cos(2.0*pi*freq*t)
+    vars = 'freq'
+    vals = '0.01666667'
+  []
+  [potential_low]
+    type = ParsedFunction
+    value = -1000*cos(2.0*pi*freq*t)
     vars = 'freq'
     vals = '0.01666667'
   []
 []
 
 [BCs]
-  [tangential_E_bc]
+  [tangential_E_bdr]
     type = MFEMVectorDirichletBC
     variable = dmagnetic_vector_potential_dt
+    boundary = '1 2 3'
     vector_coefficient = TangentialECoef
-    boundary = '1 2 3 4'
+  []
+  [high_terminal]
+    type = MFEMScalarDirichletBC
+    variable = electric_potential
+    boundary = '1'
+    coefficient = HighPotential
+  []
+  [low_terminal]
+    type = MFEMScalarDirichletBC
+    variable = electric_potential
+    boundary = '2'
+    coefficient = LowPotential
   []
 []
 
@@ -146,21 +164,23 @@
     value = 0.0
   []
 
-  [CurrentCoef]
+  [HighPotential]
     type = MFEMFunctionCoefficient
-    function = current_magnitude
+    function = potential_high
+  []
+  [LowPotential]
+    type = MFEMFunctionCoefficient
+    function = potential_low
   []
 []
 
 [Sources]
   [SourcePotential]
-    type = MFEMOpenCoilSource
-    total_current_coef = CurrentCoef
-    source_current_density_gridfunction = source_current_density
-    source_potential_gridfunction = electric_potential
-    coil_in_boundary = 1
-    coil_out_boundary = 2
-    block = 1
+    type = MFEMScalarPotentialSource
+    potential = electric_potential
+    conductivity = electrical_conductivity
+    h1_fespace = H1FESpace
+    hcurl_fespace = HCurlFESpace
   []
 []
 

--- a/examples/MFEM/coil/EBFormCoil.i
+++ b/examples/MFEM/coil/EBFormCoil.i
@@ -6,6 +6,7 @@
 
 [Problem]
   type = MFEMProblem
+  use_glvis = true
 []
 
 [Formulation]
@@ -66,26 +67,25 @@
 []
 
 [BCs]
-  [tangential_E_bc]
+  [tangential_E_bdr]
     type = MFEMVectorDirichletBC
     variable = electric_field
+    boundary = '1 2 3'
     vector_coefficient = TangentialECoef
-    boundary = '1 2 3 4'
   []
   [high_terminal]
     type = MFEMScalarDirichletBC
     variable = electric_potential
     boundary = '1'
-    function = potential_high
+    coefficient = HighPotential
   []
   [low_terminal]
     type = MFEMScalarDirichletBC
     variable = electric_potential
     boundary = '2'
-    function = potential_low
+    coefficient = LowPotential
   []
 []
-
 [Materials]
   [coil]
     type = MFEMConductor
@@ -159,9 +159,13 @@
     value = 0.0
   []
 
-  [OneCoef]
-    type = MFEMConstantCoefficient
-    value = 1.0e12
+  [HighPotential]
+    type = MFEMFunctionCoefficient
+    function = potential_high
+  []
+  [LowPotential]
+    type = MFEMFunctionCoefficient
+    function = potential_low
   []
 []
 
@@ -172,8 +176,6 @@
     conductivity = electrical_conductivity
     hcurl_fespace = HCurlFESpace
     h1_fespace = H1FESpace
-    solver_max_its = 1000
-    block = 1
   []
 []
 


### PR DESCRIPTION
Minor update reverting use of `OpenCoilSource` in examples