### PR TITLE
Fix failing eb_thermal test case after MOOSE update

### DIFF
--- a/test/tests/integration/eb_thermal/eb_thermal_coupled.i
+++ b/test/tests/integration/eb_thermal/eb_thermal_coupled.i
@@ -94,6 +94,7 @@
     conductivity = electrical_conductivity
     h1_fespace = H1FESpace
     hcurl_fespace = HCurlFESpace
+    block = '1 2'
   []
 []
 


### PR DESCRIPTION
What does this do?
- Fixes failing eb_thermal test case

What was the issue?
- The "block" variable was not specified for MFEM sources