### PR TITLE
Add MagnetostaticFormulation 

### DIFF
--- a/examples/MFEM/coil/MagnetostaticCoilCurrent.i
+++ b/examples/MFEM/coil/MagnetostaticCoilCurrent.i
@@ -1,0 +1,168 @@
+[Mesh]
+  type = ExclusiveMFEMMesh
+  file = ./coil.gen
+  dim = 3
+[]
+
+[Problem]
+  type = MFEMProblem
+  use_glvis = false
+[]
+
+[Formulation]
+  type = MagnetostaticFormulation
+  magnetic_vector_potential_name = magnetic_vector_potential
+  magnetic_reluctivity_name = magnetic_reluctivity
+  magnetic_permeability_name = magnetic_permeability
+  magnetic_flux_density_name = magnetic_flux_density
+[]
+
+[FESpaces]
+  [H1FESpace]
+    type = MFEMFESpace
+    fespace_type = H1
+    order = FIRST
+  []
+  [HCurlFESpace]
+    type = MFEMFESpace
+    fespace_type = ND
+    order = FIRST
+  []
+  [HDivFESpace]
+    type = MFEMFESpace
+    fespace_type = RT
+    order = CONSTANT
+  []
+[]
+
+[AuxVariables]
+  [magnetic_vector_potential]
+    type = MFEMVariable
+    fespace = HCurlFESpace
+  []
+  [magnetic_flux_density]
+    type = MFEMVariable
+    fespace = HDivFESpace
+  []
+  [source_current_density]
+    type = MFEMVariable
+    fespace = HCurlFESpace
+  []
+  [electric_potential]
+    type = MFEMVariable
+    fespace = H1FESpace
+  []
+[]
+
+[BCs]
+  [tangential_E_bc]
+    type = MFEMVectorDirichletBC
+    variable = magnetic_vector_potential
+    vector_coefficient = TangentialECoef
+    boundary = '1 2 4'
+  []
+[]
+
+[Materials]
+  [coil]
+    type = MFEMConductor
+    electrical_conductivity_coeff = CoilEConductivity
+    electric_permittivity_coeff = CoilPermittivity
+    magnetic_permeability_coeff = CoilPermeability
+    block = 1
+  []
+  [air]
+    type = MFEMConductor
+    electrical_conductivity_coeff = AirEConductivity
+    electric_permittivity_coeff = AirPermittivity
+    magnetic_permeability_coeff = AirPermeability
+    block = 2
+  []
+  [core]
+    type = MFEMConductor
+    electrical_conductivity_coeff = CoreEConductivity
+    electric_permittivity_coeff = CorePermittivity
+    magnetic_permeability_coeff = CorePermeability
+    block = 3
+  []
+[]
+
+[VectorCoefficients]
+  [TangentialECoef]
+    type = MFEMVectorConstantCoefficient
+    value_x = 0.0
+    value_y = 0.0
+    value_z = 0.0
+  []
+[]
+
+[Coefficients]
+  [CoilEConductivity]
+    type = MFEMConstantCoefficient
+    value = 62.83185
+  []
+  [CoilPermeability]
+    type = MFEMConstantCoefficient
+    value = 1.0
+  []
+  [CoilPermittivity]
+    type = MFEMConstantCoefficient
+    value = 0.0
+  []
+
+  [AirEConductivity]
+    type = MFEMConstantCoefficient
+    value = 62.83185e-6
+  []
+  [AirPermeability]
+    type = MFEMConstantCoefficient
+    value = 1.0
+  []
+  [AirPermittivity]
+    type = MFEMConstantCoefficient
+    value = 0.0
+  []
+
+  [CoreEConductivity]
+    type = MFEMConstantCoefficient
+    value = 62.83185e-6
+  []
+  [CorePermeability]
+    type = MFEMConstantCoefficient
+    value = 1.0
+  []
+  [CorePermittivity]
+    type = MFEMConstantCoefficient
+    value = 0.0
+  []
+
+  [CurrentCoef]
+    type = MFEMConstantCoefficient
+    value = 0.1
+  []
+[]
+
+[Sources]
+  [SourcePotential]
+    type = MFEMOpenCoilSource
+    total_current_coef = CurrentCoef
+    source_current_density_gridfunction = source_current_density
+    source_potential_gridfunction = electric_potential
+    coil_in_boundary = 1
+    coil_out_boundary = 2
+    block = 1
+  []
+[]
+
+[Executioner]
+  type = Steady
+  l_tol = 1e-6
+  l_max_its = 10
+[]
+
+[Outputs]
+  [ParaViewDataCollection]
+    type = MFEMParaViewDataCollection
+    file_base = OutputData/ParaViewMagnetostaticCoil
+  []
+[]

--- a/examples/MFEM/coil/MagnetostaticCoilPotential.i
+++ b/examples/MFEM/coil/MagnetostaticCoilPotential.i
@@ -1,0 +1,183 @@
+[Mesh]
+  type = ExclusiveMFEMMesh
+  file = ./coil.gen
+  dim = 3
+[]
+
+[Problem]
+  type = MFEMProblem
+  use_glvis = false
+[]
+
+[Formulation]
+  type = MagnetostaticFormulation
+  magnetic_vector_potential_name = magnetic_vector_potential
+  magnetic_reluctivity_name = magnetic_reluctivity
+  magnetic_permeability_name = magnetic_permeability
+  magnetic_flux_density_name = magnetic_flux_density
+[]
+
+[FESpaces]
+  [H1FESpace]
+    type = MFEMFESpace
+    fespace_type = H1
+    order = FIRST
+  []
+  [HCurlFESpace]
+    type = MFEMFESpace
+    fespace_type = ND
+    order = FIRST
+  []
+  [HDivFESpace]
+    type = MFEMFESpace
+    fespace_type = RT
+    order = CONSTANT
+  []
+[]
+
+[AuxVariables]
+  [magnetic_vector_potential]
+    type = MFEMVariable
+    fespace = HCurlFESpace
+  []
+  [magnetic_flux_density]
+    type = MFEMVariable
+    fespace = HDivFESpace
+  []
+  [source_current_density]
+    type = MFEMVariable
+    fespace = HCurlFESpace
+  []
+  [electric_potential]
+    type = MFEMVariable
+    fespace = H1FESpace
+  []
+[]
+
+[BCs]
+  [tangential_E_bdr]
+    type = MFEMVectorDirichletBC
+    variable = magnetic_vector_potential
+    boundary = '1 2 4'
+    vector_coefficient = TangentialECoef
+  []
+  [high_terminal]
+    type = MFEMScalarDirichletBC
+    variable = electric_potential
+    boundary = '1'
+    coefficient = HighPotential
+  []
+  [low_terminal]
+    type = MFEMScalarDirichletBC
+    variable = electric_potential
+    boundary = '2'
+    coefficient = LowPotential
+  []
+[]
+
+[Materials]
+  [coil]
+    type = MFEMConductor
+    electrical_conductivity_coeff = CoilEConductivity
+    electric_permittivity_coeff = CoilPermittivity
+    magnetic_permeability_coeff = CoilPermeability
+    block = 1
+  []
+  [air]
+    type = MFEMConductor
+    electrical_conductivity_coeff = AirEConductivity
+    electric_permittivity_coeff = AirPermittivity
+    magnetic_permeability_coeff = AirPermeability
+    block = 2
+  []
+  [core]
+    type = MFEMConductor
+    electrical_conductivity_coeff = CoreEConductivity
+    electric_permittivity_coeff = CorePermittivity
+    magnetic_permeability_coeff = CorePermeability
+    block = 3
+  []
+[]
+
+[VectorCoefficients]
+  [TangentialECoef]
+    type = MFEMVectorConstantCoefficient
+    value_x = 0.0
+    value_y = 0.0
+    value_z = 0.0
+  []
+[]
+
+[Coefficients]
+  [CoilEConductivity]
+    type = MFEMConstantCoefficient
+    value = 62.83185
+  []
+  [CoilPermeability]
+    type = MFEMConstantCoefficient
+    value = 1.0
+  []
+  [CoilPermittivity]
+    type = MFEMConstantCoefficient
+    value = 0.0
+  []
+
+  [AirEConductivity]
+    type = MFEMConstantCoefficient
+    value = 62.83185e-6
+  []
+  [AirPermeability]
+    type = MFEMConstantCoefficient
+    value = 1.0
+  []
+  [AirPermittivity]
+    type = MFEMConstantCoefficient
+    value = 0.0
+  []
+
+  [CoreEConductivity]
+    type = MFEMConstantCoefficient
+    value = 62.83185e-6
+  []
+  [CorePermeability]
+    type = MFEMConstantCoefficient
+    value = 1.0
+  []
+  [CorePermittivity]
+    type = MFEMConstantCoefficient
+    value = 0.0
+  []
+
+  [HighPotential]
+    type = MFEMConstantCoefficient
+    value = 1.0
+  []
+  [LowPotential]
+    type = MFEMConstantCoefficient
+    value = -1.0
+  []
+[]
+
+[Sources]
+  [SourcePotential]
+    type = MFEMScalarPotentialSource
+    potential = electric_potential
+    conductivity = electrical_conductivity
+    h1_fespace = H1FESpace
+    hcurl_fespace = HCurlFESpace
+    block = 1
+  []
+[]
+
+[Executioner]
+  type = Steady
+  l_tol = 1e-6
+  l_max_its = 10
+[]
+
+[Outputs]
+  [ParaViewDataCollection]
+    type = MFEMParaViewDataCollection
+    file_base = OutputData/ParaViewMagnetostaticCoil
+  []
+[]

--- a/include/formulations/MagnetostaticFormulation.h
+++ b/include/formulations/MagnetostaticFormulation.h
@@ -1,0 +1,36 @@
+#pragma once
+
+#include "MFEMFormulation.h"
+#include "factory.hpp"
+/*
+Solves:MFEM formulation for solving:
+∇×(ν∇×A) = Jᵉ
+
+in weak form
+(ν∇×A, ∇×A') - (Jᵉ, A') - <(ν∇×A)×n, A'>  = 0
+
+where:
+Magnetic reluctivity ν = 1/μ
+Magnetic vector potential A
+Magnetic flux density, B = ∇×A
+Magnetic field H = ν∇×A
+*/
+class MagnetostaticFormulation : public MFEMFormulation
+{
+public:
+  static InputParameters validParams();
+
+  MagnetostaticFormulation(const InputParameters & parameters);
+  virtual ~MagnetostaticFormulation();
+
+  virtual void execute() override {}
+  virtual void initialize() override {}
+  virtual void finalize() override {}
+  virtual hephaestus::ProblemBuilder * getProblemBuilder() override { return &formulation; };
+
+private:
+  std::string magnetic_vector_potential_name;
+  std::string magnetic_permeability_name;
+  std::string magnetic_reluctivity_name;
+  hephaestus::MagnetostaticFormulation formulation;
+};

--- a/src/formulations/MagnetostaticFormulation.C
+++ b/src/formulations/MagnetostaticFormulation.C
@@ -1,0 +1,48 @@
+#include "MagnetostaticFormulation.h"
+
+registerMooseObject("ApolloApp", MagnetostaticFormulation);
+
+InputParameters
+MagnetostaticFormulation::validParams()
+{
+  InputParameters params = MFEMFormulation::validParams();
+  params.addRequiredParam<std::string>(
+      "magnetic_vector_potential_name",
+      "Name of H(curl) conforming MFEM gridfunction representing magnetic vector potential");
+  params.addRequiredParam<std::string>(
+      "magnetic_permeability_name", "Name of MFEM coefficient representing magnetic permeability");
+  params.addRequiredParam<std::string>(
+      "magnetic_reluctivity_name",
+      "Name of MFEM coefficient to be created to represent magnetic "
+      "reluctivity (reciprocal of permeability)");
+  params.addParam<std::string>(
+      "magnetic_flux_density_name",
+      "Name of H(Div) conforming MFEM gridfunction to store magnetic flux density");
+  params.addParam<std::string>(
+      "magnetic_field_name",
+      "Name of H(Curl) conforming MFEM gridfunction to store magnetic field");
+  params.addParam<std::string>(
+      "lorentz_force_density_name",
+      "Name of L2 conforming MFEM gridfunction to store Lorentz force density");
+  return params;
+}
+
+MagnetostaticFormulation::MagnetostaticFormulation(const InputParameters & parameters)
+  : MFEMFormulation(parameters),
+    magnetic_vector_potential_name(getParam<std::string>("magnetic_vector_potential_name")),
+    magnetic_permeability_name(getParam<std::string>("magnetic_permeability_name")),
+    magnetic_reluctivity_name(getParam<std::string>("magnetic_reluctivity_name")),
+    formulation(
+        magnetic_reluctivity_name, magnetic_permeability_name, magnetic_vector_potential_name)
+{
+  if (isParamValid("magnetic_flux_density_name"))
+    formulation.registerMagneticFluxDensityAux(getParam<std::string>("magnetic_flux_density_name"));
+  if (isParamValid("magnetic_field_name"))
+    formulation.registerMagneticFieldAux(getParam<std::string>("magnetic_field_name"));
+  if (isParamValid("lorentz_force_density_name"))
+    formulation.registerLorentzForceDensityAux(getParam<std::string>("lorentz_force_density_name"),
+                                               getParam<std::string>("magnetic_flux_density_name"),
+                                               getParam<std::string>("current_density_name"));
+}
+
+MagnetostaticFormulation::~MagnetostaticFormulation() {}


### PR DESCRIPTION
Adds a support for using `hephaestus::MagnetostaticFormulation` for steady state solves of the magnetic field associated with a supplied source current.

Also adds the `MagnetostaticCoilCurrent.i` and `MagnetostaticCoilPotential.i` examples to demonstrate usage.