### PR TITLE
"solve = false" now works for MFEMProblem

### DIFF
--- a/src/problem/MFEMProblem.C
+++ b/src/problem/MFEMProblem.C
@@ -128,6 +128,11 @@ MFEMProblem::init()
 void
 MFEMProblem::externalSolve()
 {
+  if (!_solve)
+  {
+    return;
+  }
+
   hephaestus::TransientExecutioner * transient_mfem_exec =
       dynamic_cast<hephaestus::TransientExecutioner *>(executioner);
   if (transient_mfem_exec != NULL)


### PR DESCRIPTION
Why is this useful?

- This means that dummy kernels are no longer required for simple test cases.
- Enables much simpler tests to be written for testing transfers/auxkernels.