### PR TITLE
Add additional variable-dependent function coefficients

### DIFF
--- a/include/coefficients/MFEMTemperatureDependentConductivityCoefficient.h
+++ b/include/coefficients/MFEMTemperatureDependentConductivityCoefficient.h
@@ -1,0 +1,24 @@
+#pragma once
+#include "MFEMCoefficient.h"
+#include "auxsolvers.hpp"
+
+class MFEMTemperatureDependentConductivityCoefficient : public MFEMCoefficient,
+                                                        public hephaestus::CoupledCoefficient
+{
+public:
+  static InputParameters validParams();
+
+  MFEMTemperatureDependentConductivityCoefficient(const InputParameters & parameters);
+  virtual ~MFEMTemperatureDependentConductivityCoefficient();
+
+  virtual void execute() override{};
+  virtual void initialize() override{};
+  virtual void finalize() override{};
+
+  double Eval(mfem::ElementTransformation & trans, const mfem::IntegrationPoint & ip) override;
+
+  virtual mfem::Coefficient * getCoefficient() override { return this; };
+
+private:
+  const Function & _func;
+};

--- a/include/coefficients/MFEMVariableDependentFunctionCoefficient.h
+++ b/include/coefficients/MFEMVariableDependentFunctionCoefficient.h
@@ -1,0 +1,24 @@
+#pragma once
+#include "MFEMCoefficient.h"
+#include "auxsolvers.hpp"
+
+class MFEMVariableDependentFunctionCoefficient : public MFEMCoefficient,
+                                                 public hephaestus::CoupledCoefficient
+{
+public:
+  static InputParameters validParams();
+
+  MFEMVariableDependentFunctionCoefficient(const InputParameters & parameters);
+  virtual ~MFEMVariableDependentFunctionCoefficient();
+
+  virtual void execute() override{};
+  virtual void initialize() override{};
+  virtual void finalize() override{};
+
+  double Eval(mfem::ElementTransformation & trans, const mfem::IntegrationPoint & ip) override;
+
+  virtual mfem::Coefficient * getCoefficient() override { return this; };
+
+private:
+  const Function & _func;
+};

--- a/src/base/ApolloApp.C
+++ b/src/base/ApolloApp.C
@@ -38,6 +38,8 @@ associateSyntaxInner(Syntax & syntax, ActionFactory & /*action_factory*/)
   registerMooseObjectTask("add_mfem_coefficients", MFEMCoefficient, false);
   registerSyntaxTask("AddCoefficientAction", "Coefficients/*", "add_mfem_coefficients");
   addTaskDependency("add_material", "add_mfem_coefficients");
+  addTaskDependency("add_mfem_coefficients", "add_variable");
+  addTaskDependency("add_mfem_coefficients", "add_aux_variable");
 
   // add vector coefficients
   registerMooseObjectTask("add_mfem_vector_coefficients", MFEMVectorCoefficient, false);

--- a/src/coefficients/MFEMTemperatureDependentConductivityCoefficient.C
+++ b/src/coefficients/MFEMTemperatureDependentConductivityCoefficient.C
@@ -1,0 +1,35 @@
+#include "MFEMTemperatureDependentConductivityCoefficient.h"
+
+registerMooseObject("ApolloApp", MFEMTemperatureDependentConductivityCoefficient);
+
+InputParameters
+MFEMTemperatureDependentConductivityCoefficient::validParams()
+{
+  InputParameters params = MFEMCoefficient::validParams();
+  params.addParam<FunctionName>(
+      "resistivity_function", 1.0, "The resistivity of the material as a function of temperature");
+  params.addParam<std::string>("temperature_variable",
+                               "The MFEMVariable describing the temperature of the material.");
+  return params;
+}
+
+MFEMTemperatureDependentConductivityCoefficient::MFEMTemperatureDependentConductivityCoefficient(
+    const InputParameters & parameters)
+  : MFEMCoefficient(parameters),
+    hephaestus::CoupledCoefficient(hephaestus::InputParameters(
+        {{"CoupledVariableName", getParam<std::string>("temperature_variable")}})),
+    _func(getFunction("resistivity_function"))
+{
+}
+
+double
+MFEMTemperatureDependentConductivityCoefficient::Eval(mfem::ElementTransformation & trans,
+                                                      const mfem::IntegrationPoint & ip)
+{
+  auto gf_value{hephaestus::CoupledCoefficient::Eval(trans, ip)};
+  return 1.0 / _func.value(gf_value);
+};
+
+MFEMTemperatureDependentConductivityCoefficient::~MFEMTemperatureDependentConductivityCoefficient()
+{
+}

--- a/src/coefficients/MFEMVariableDependentFunctionCoefficient.C
+++ b/src/coefficients/MFEMVariableDependentFunctionCoefficient.C
@@ -1,0 +1,33 @@
+#include "MFEMVariableDependentFunctionCoefficient.h"
+
+registerMooseObject("ApolloApp", MFEMVariableDependentFunctionCoefficient);
+
+InputParameters
+MFEMVariableDependentFunctionCoefficient::validParams()
+{
+  InputParameters params = MFEMCoefficient::validParams();
+  params.addParam<FunctionName>(
+      "function", 1, "The function acting on the MFEM variable to return the coefficient");
+
+  params.addParam<std::string>("coupled_variable", "The MFEMVariable the coefficient depends on.");
+  return params;
+}
+
+MFEMVariableDependentFunctionCoefficient::MFEMVariableDependentFunctionCoefficient(
+    const InputParameters & parameters)
+  : MFEMCoefficient(parameters),
+    hephaestus::CoupledCoefficient(hephaestus::InputParameters(
+        {{"CoupledVariableName", getParam<std::string>("coupled_variable")}})),
+    _func(getFunction("function"))
+{
+}
+
+double
+MFEMVariableDependentFunctionCoefficient::Eval(mfem::ElementTransformation & trans,
+                                               const mfem::IntegrationPoint & ip)
+{
+  auto gf_value{hephaestus::CoupledCoefficient::Eval(trans, ip)};
+  return _func.value(gf_value);
+};
+
+MFEMVariableDependentFunctionCoefficient::~MFEMVariableDependentFunctionCoefficient() {}


### PR DESCRIPTION
Adds new `MFEMVariableDependentFunctionCoefficient` to allow MOOSE functions of one MFEMVariable to be used as MFEM Coefficients during a solve. Generalisation of existing `MFEMParsedCoefficient`.

Also adds a dedicated `MFEMTemperatureDependentConductivityCoefficient` to simplify setup of temperature-dependent conductivities for coupled EM solve, given the frequency of this use case. Users will no longer need to set these up using `MFEMParsedCoefficient` directly.