### PR TITLE
MFEMProblem Cleanup [Stack PR #3]

### DIFF
--- a/include/problem/MFEMProblem.h
+++ b/include/problem/MFEMProblem.h
@@ -124,6 +124,7 @@ public:
   void addAuxKernel(const std::string & kernel_name,
                     const std::string & name,
                     InputParameters & parameters) override;
+
   /**
    * setMFEMVarData and setMOOSEVarData have very similar uses. They are both used to retrieve
    * data from one of the variable types (either Moose AuxVar or MFEM grid function), and
@@ -131,6 +132,7 @@ public:
    * setMFEMVarData to get this temperature data into an MFEM grid function.
    */
   void setMFEMVarData(std::string var_name, EquationSystems & esRef);
+
   /**
    * setMFEMVarData and setMOOSEVarData have very similar uses. They are both used to retrieve data
    * from one of the variable types (either Moose AuxVar or MFEM grid function), and transfer it to
@@ -147,6 +149,12 @@ public:
   InputParameters addMFEMFESpaceFromMOOSEVariable(InputParameters & moosevar_params);
 
 protected:
+  /**
+   * Called internally by setMFEMVarData.
+   */
+  void setMFEMNodalVarData(MooseVariableFieldBase & moose_variable);
+  void setMFEMElementalVarData(MooseVariableFieldBase & moose_variable);
+
   std::string _input_mesh;
   std::string _formulation_name;
   int _order;

--- a/include/problem/MFEMProblem.h
+++ b/include/problem/MFEMProblem.h
@@ -131,8 +131,8 @@ public:
    * transfer it to the other. For example if you solve for temperature in MOOSE, you would use
    * setMFEMVarData to get this temperature data into an MFEM grid function.
    */
-  void setMFEMVarData(std::string var_name, EquationSystems & esRef);
-  void setMOOSEVarData(std::string var_name, EquationSystems & esRef);
+  void setMFEMVarData(const std::string & var_name);
+  void setMOOSEVarData(const std::string & var_name);
 
   /**
    * Method used to get an mfem FEC depending on the variable family specified in the input file.

--- a/include/problem/MFEMProblem.h
+++ b/include/problem/MFEMProblem.h
@@ -132,13 +132,6 @@ public:
    * setMFEMVarData to get this temperature data into an MFEM grid function.
    */
   void setMFEMVarData(std::string var_name, EquationSystems & esRef);
-
-  /**
-   * setMFEMVarData and setMOOSEVarData have very similar uses. They are both used to retrieve data
-   * from one of the variable types (either Moose AuxVar or MFEM grid function), and transfer it to
-   * the other. For example if you solve for temperature in MOOSE, you would use setMFEMVarData to
-   * get this temperature data into an MFEM grid function.
-   */
   void setMOOSEVarData(std::string var_name, EquationSystems & esRef);
 
   /**
@@ -154,6 +147,12 @@ protected:
    */
   void setMFEMNodalVarData(MooseVariableFieldBase & moose_variable);
   void setMFEMElementalVarData(MooseVariableFieldBase & moose_variable);
+
+  /**
+   * Called internally by setMooseVarData.
+   */
+  void setMooseNodalVarData(MooseVariableFieldBase & moose_variable);
+  void setMooseElementalVarData(MooseVariableFieldBase & moose_variable);
 
   std::string _input_mesh;
   std::string _formulation_name;

--- a/src/problem/MFEMProblem.C
+++ b/src/problem/MFEMProblem.C
@@ -421,6 +421,8 @@ MFEMProblem::setMFEMElementalVarData(MooseVariableFieldBase & moose_var_ref)
   mooseAssert(moose_var_ref.isNodal() == false, "Variable must not be nodal.");
 
   auto order = (unsigned int)moose_var_ref.order();
+  mooseAssert((n_processors() == 1) || (n_processors() > 1 && order == CONSTANT),
+              "Currently, only constant-order elemental variables can be synced in parallel.");
 
   auto & libmesh_base = mesh().getMesh();
   auto & temp_solution_vector = moose_var_ref.sys().solution();
@@ -463,10 +465,9 @@ MFEMProblem::setMooseNodalVarData(MooseVariableFieldBase & moose_var_ref)
 {
   mooseAssert(moose_var_ref.isNodal() == true, "Variable must be nodal.");
 
-  auto & libmesh_base = mesh().getMesh();
-
   auto order = (unsigned int)moose_var_ref.order();
 
+  auto & libmesh_base = mesh().getMesh();
   auto & temp_solution_vector = moose_var_ref.sys().solution();
   auto & pgf = *(mfem_problem->gridfunctions.Get(moose_var_ref.name()));
 
@@ -521,6 +522,10 @@ void
 MFEMProblem::setMooseElementalVarData(MooseVariableFieldBase & moose_var_ref)
 {
   mooseAssert(moose_var_ref.isNodal() == false, "Variable must not be nodal.");
+
+  auto order = (unsigned int)moose_var_ref.order();
+  mooseAssert((n_processors() == 1) || (n_processors() > 1 && order == CONSTANT),
+              "Currently, only constant-order elemental variables can be synced in parallel.");
 
   auto & libmesh_base = mesh().getMesh();
   auto & temp_solution_vector = moose_var_ref.sys().solution();

--- a/src/problem/MFEMProblem.C
+++ b/src/problem/MFEMProblem.C
@@ -314,7 +314,7 @@ MFEMProblem::addAuxKernel(const std::string & kernel_name,
 }
 
 void
-MFEMProblem::setMFEMVarData(std::string var_name, EquationSystems & esRef)
+MFEMProblem::setMFEMVarData(const std::string & var_name)
 {
   auto & moose_var_ref = getVariable(0, var_name);
 
@@ -325,7 +325,7 @@ MFEMProblem::setMFEMVarData(std::string var_name, EquationSystems & esRef)
 }
 
 void
-MFEMProblem::setMOOSEVarData(std::string var_name, EquationSystems & esRef)
+MFEMProblem::setMOOSEVarData(const std::string & var_name)
 {
   auto & moose_var_ref = getVariable(0, var_name);
 
@@ -607,7 +607,7 @@ MFEMProblem::syncSolutions(Direction direction)
     return;
   }
 
-  void (MFEMProblem::*setVarDataFuncPtr)(std::string, EquationSystems &);
+  void (MFEMProblem::*setVarDataFuncPtr)(const std::string &);
 
   switch (direction)
   {
@@ -629,9 +629,9 @@ MFEMProblem::syncSolutions(Direction direction)
     mooseError("Invalid syncSolutions direction specified.");
   }
 
-  for (std::string name : getAuxVariableNames())
+  for (std::string & name : getAuxVariableNames())
   {
-    (this->*setVarDataFuncPtr)(name, es());
+    (this->*setVarDataFuncPtr)(name);
   }
 }
 


### PR DESCRIPTION
**Changes**
- Greatly improved readability in MFEMProblem by extracting setMFEMVarData and setMooseVarData methods into individual methods based on whether the variable in question is nodal.
- Modernized C++ by using auto keyword and decltype.
- Fixed memory leaks where a hypre vector was not deleted.
- Removed redundant method arguments and strings now passed as an argument by reference.
- Added check to ensure that higher-order monomials are not synced in parallel (support for this can be added in future).