### PR TITLE
Update Hephaestus Version [Before Memory Leak Fixes Applied] And Fix Failing Tests

### DIFF
--- a/include/sources/MFEMScalarPotentialSource.h
+++ b/include/sources/MFEMScalarPotentialSource.h
@@ -19,6 +19,7 @@ public:
 protected:
   std::string source_coef_name;
   std::string potential_name;
+  std::string grad_electric_potential_name;
   std::string conductivity_coef_name;
   const MFEMFESpace & hcurl_fespace;
   const MFEMFESpace & h1_fespace;

--- a/src/auxkernels/MFEMJouleHeatingAux.C
+++ b/src/auxkernels/MFEMJouleHeatingAux.C
@@ -29,7 +29,7 @@ void
 MFEMJouleHeatingAux::storeCoefficients(hephaestus::Coefficients & coefficients)
 {
   std::string coef_name = std::string("JouleHeating");
-  coefficients.scalars.Register(coef_name, &joule_heating_aux, true);
+  coefficients.scalars.Register(coef_name, &joule_heating_aux, false);
 }
 
 MFEMJouleHeatingAux::~MFEMJouleHeatingAux() {}

--- a/src/problem/MFEMProblem.C
+++ b/src/problem/MFEMProblem.C
@@ -292,7 +292,7 @@ MFEMProblem::addAuxKernel(const std::string & kernel_name,
     FEProblemBase::addUserObject(kernel_name, name, parameters);
     MFEMAuxSolver * mfem_auxsolver(&getUserObject<MFEMAuxSolver>(name));
 
-    mfem_problem_builder->AddPostprocessor(name, mfem_auxsolver->getAuxSolver(), true);
+    mfem_problem_builder->AddPostprocessor(name, mfem_auxsolver->getAuxSolver(), false);
     mfem_auxsolver->storeCoefficients(_coefficients);
   }
   else if (base_auxkernel == "AuxKernel" || base_auxkernel == "VectorAuxKernel" ||

--- a/src/sources/MFEMScalarPotentialSource.C
+++ b/src/sources/MFEMScalarPotentialSource.C
@@ -9,6 +9,8 @@ MFEMScalarPotentialSource::validParams()
   params.addRequiredParam<std::string>(
       "potential",
       "Name of the potential used in the solver, necessary to find boundary conditions");
+  params.addRequiredParam<std::string>("grad_electric_potential",
+                                       "Name of the gradient of the electric potential.");
   params.addRequiredParam<std::string>(
       "conductivity", "Name of the conductivity coefficient associated with the potential.");
   params.addRequiredParam<UserObjectName>("hcurl_fespace",
@@ -28,6 +30,7 @@ MFEMScalarPotentialSource::MFEMScalarPotentialSource(const InputParameters & par
   : MFEMSource(parameters),
     source_coef_name(std::string("source_") + getParam<std::string>("_object_name")),
     potential_name(getParam<std::string>("potential")),
+    grad_electric_potential_name(getParam<std::string>("grad_electric_potential")),
     conductivity_coef_name(getParam<std::string>("conductivity")),
     hcurl_fespace(getUserObject<MFEMFESpace>("hcurl_fespace")),
     h1_fespace(getUserObject<MFEMFESpace>("h1_fespace"))
@@ -48,6 +51,7 @@ MFEMScalarPotentialSource::MFEMScalarPotentialSource(const InputParameters & par
   hephaestus::InputParameters scalar_potential_source_params;
   scalar_potential_source_params.SetParam("SourceName", source_coef_name);
   scalar_potential_source_params.SetParam("PotentialName", potential_name);
+  scalar_potential_source_params.SetParam("GradPotentialName", grad_electric_potential_name);
   scalar_potential_source_params.SetParam("ConductivityCoefName", conductivity_coef_name);
   scalar_potential_source_params.SetParam("HCurlFESpaceName", hcurl_fespace.name());
   scalar_potential_source_params.SetParam("H1FESpaceName", h1_fespace.name());

--- a/test/tests/integration/ebform_rod/rod.i
+++ b/test/tests/integration/ebform_rod/rod.i
@@ -48,6 +48,10 @@
     type = MFEMVariable
     fespace = H1FESpace
   []
+  [grad_electric_potential]
+    type = MFEMVariable 
+    fespace = HCurlFESpace
+  []
 []
 
 [Functions]
@@ -90,6 +94,7 @@
   [SourcePotential]
     type = MFEMScalarPotentialSource
     potential = electric_potential
+    grad_electric_potential = grad_electric_potential
     h1_fespace = H1FESpace
     hcurl_fespace = HCurlFESpace
     conductivity = electrical_conductivity

--- a/test/tests/integration/test_em_thermal/em_coupled.i
+++ b/test/tests/integration/test_em_thermal/em_coupled.i
@@ -49,6 +49,10 @@
     type = MFEMVariable
     fespace = H1FESpace
   []
+  [grad_electric_potential]
+    type = MFEMVariable 
+    fespace = HCurlFESpace
+  []
 []
 
 [Functions]
@@ -121,6 +125,7 @@
   [SourcePotential]
     type = MFEMScalarPotentialSource
     potential = electric_potential
+    grad_electric_potential = grad_electric_potential
     conductivity = electrical_conductivity
     h1_fespace = H1FESpace
     hcurl_fespace = HCurlFESpace


### PR DESCRIPTION
**Changes**
- Fixed incorrect Registering of variables in Apollo.
- Apollo now using a newer version of Hephaestus.
- Fixed tests broken by new version of Hephaestus.