### PR TITLE
Add Shared Pointers to Apollo and Update Hephaestus

### DIFF
--- a/include/auxkernels/MFEMAuxSolver.h
+++ b/include/auxkernels/MFEMAuxSolver.h
@@ -16,10 +16,10 @@ public:
   virtual void initialize() override {}
   virtual void finalize() override {}
 
-  virtual hephaestus::AuxSolver * getAuxSolver();
+  inline virtual std::shared_ptr<hephaestus::AuxSolver> getAuxSolver() const { return _auxsolver; }
 
   virtual void storeCoefficients(hephaestus::Coefficients & coefficients) {}
 
 protected:
-  hephaestus::AuxSolver * _auxsolver;
+  std::shared_ptr<hephaestus::AuxSolver> _auxsolver{nullptr};
 };

--- a/include/auxkernels/MFEMJouleHeatingAux.h
+++ b/include/auxkernels/MFEMJouleHeatingAux.h
@@ -30,7 +30,7 @@ public:
 
     hephaestus::CoupledCoefficient::Init(variables, coefficients);
     std::cout << "Intialising JouleHeating";
-    sigma = coefficients.scalars.Get(conductivity_coef_name);
+    sigma = coefficients._scalars.Get(conductivity_coef_name);
 
     joule_heating_gf = variables.Get("joule_heating");
   }
@@ -39,7 +39,7 @@ public:
   {
     mfem::Vector E;
     double thisSigma;
-    gf->GetVectorValue(T, ip, E);
+    _gf->GetVectorValue(T, ip, E);
     thisSigma = sigma->Eval(T, ip);
     return thisSigma * (E * E);
   }

--- a/include/auxkernels/MFEMJouleHeatingAux.h
+++ b/include/auxkernels/MFEMJouleHeatingAux.h
@@ -63,10 +63,14 @@ public:
   virtual void initialize() override {}
   virtual void finalize() override {}
 
-  virtual hephaestus::AuxSolver * getAuxSolver() override;
+  inline std::shared_ptr<hephaestus::AuxSolver> getAuxSolver() const override
+  {
+    return joule_heating_aux;
+  }
+
   virtual void storeCoefficients(hephaestus::Coefficients & coefficients) override;
 
 protected:
   hephaestus::InputParameters joule_heating_params;
-  JouleHeatingCoefficient joule_heating_aux;
+  std::shared_ptr<JouleHeatingCoefficient> joule_heating_aux;
 };

--- a/include/bcs/MFEMBoundaryCondition.h
+++ b/include/bcs/MFEMBoundaryCondition.h
@@ -14,7 +14,10 @@ public:
   MFEMBoundaryCondition(const InputParameters & parameters);
   ~MFEMBoundaryCondition() override {}
 
-  inline virtual std::shared_ptr<hephaestus::BoundaryCondition> getBC() const { return _boundary_condition; }
+  inline virtual std::shared_ptr<hephaestus::BoundaryCondition> getBC() const
+  {
+    return _boundary_condition;
+  }
 
   virtual void execute() override {}
   virtual void initialize() override {}
@@ -23,5 +26,6 @@ public:
 protected:
   std::vector<BoundaryName> _boundary_names;
   mfem::Array<int> bdr_attr;
+
   std::shared_ptr<hephaestus::BoundaryCondition> _boundary_condition{nullptr};
 };

--- a/include/bcs/MFEMBoundaryCondition.h
+++ b/include/bcs/MFEMBoundaryCondition.h
@@ -12,9 +12,10 @@ public:
   static InputParameters validParams();
 
   MFEMBoundaryCondition(const InputParameters & parameters);
-  virtual ~MFEMBoundaryCondition();
+  ~MFEMBoundaryCondition() override {}
 
-  virtual hephaestus::BoundaryCondition * getBC();
+  inline virtual std::shared_ptr<hephaestus::BoundaryCondition> getBC() const { return _boundary_condition; }
+
   virtual void execute() override {}
   virtual void initialize() override {}
   virtual void finalize() override {}
@@ -22,5 +23,5 @@ public:
 protected:
   std::vector<BoundaryName> _boundary_names;
   mfem::Array<int> bdr_attr;
-  hephaestus::BoundaryCondition * _boundary_condition;
+  std::shared_ptr<hephaestus::BoundaryCondition> _boundary_condition{nullptr};
 };

--- a/include/bcs/MFEMComplexVectorDirichletBC.h
+++ b/include/bcs/MFEMComplexVectorDirichletBC.h
@@ -10,15 +10,13 @@ public:
   static InputParameters validParams();
 
   MFEMComplexVectorDirichletBC(const InputParameters & parameters);
-  virtual ~MFEMComplexVectorDirichletBC();
+  ~MFEMComplexVectorDirichletBC() override {}
 
-  virtual hephaestus::BoundaryCondition * getBC() override;
   virtual void execute() override {}
   virtual void initialize() override {}
   virtual void finalize() override {}
 
 protected:
-  MFEMVectorCoefficient * _vec_coef_re;
-  MFEMVectorCoefficient * _vec_coef_im;
-  hephaestus::VectorDirichletBC _boundary_condition;
+  MFEMVectorCoefficient * _vec_coef_re{nullptr};
+  MFEMVectorCoefficient * _vec_coef_im{nullptr};
 };

--- a/include/bcs/MFEMRWTE10PortRBC.h
+++ b/include/bcs/MFEMRWTE10PortRBC.h
@@ -11,9 +11,8 @@ public:
   static InputParameters validParams();
 
   MFEMRWTE10PortRBC(const InputParameters & parameters);
-  virtual ~MFEMRWTE10PortRBC();
+  ~MFEMRWTE10PortRBC() override{};
 
-  virtual hephaestus::BoundaryCondition * getBC() override;
   virtual void execute() override {}
   virtual void initialize() override {}
   virtual void finalize() override {}

--- a/include/bcs/MFEMRWTE10PortRBC.h
+++ b/include/bcs/MFEMRWTE10PortRBC.h
@@ -11,7 +11,7 @@ public:
   static InputParameters validParams();
 
   MFEMRWTE10PortRBC(const InputParameters & parameters);
-  ~MFEMRWTE10PortRBC() override{};
+  ~MFEMRWTE10PortRBC() override {}
 
   virtual void execute() override {}
   virtual void initialize() override {}

--- a/include/bcs/MFEMScalarDirichletBC.h
+++ b/include/bcs/MFEMScalarDirichletBC.h
@@ -10,13 +10,12 @@ public:
   static InputParameters validParams();
 
   MFEMScalarDirichletBC(const InputParameters & parameters);
+  ~MFEMScalarDirichletBC() override {}
 
-  virtual hephaestus::BoundaryCondition * getBC() override;
   virtual void execute() override {}
   virtual void initialize() override {}
   virtual void finalize() override {}
 
 protected:
-  MFEMCoefficient * _coef;
-  hephaestus::ScalarDirichletBC _boundary_condition;
+  MFEMCoefficient * _coef{nullptr};
 };

--- a/include/bcs/MFEMVectorDirichletBC.h
+++ b/include/bcs/MFEMVectorDirichletBC.h
@@ -10,14 +10,12 @@ public:
   static InputParameters validParams();
 
   MFEMVectorDirichletBC(const InputParameters & parameters);
-  virtual ~MFEMVectorDirichletBC();
+  ~MFEMVectorDirichletBC() override {}
 
-  virtual hephaestus::BoundaryCondition * getBC() override;
   virtual void execute() override {}
   virtual void initialize() override {}
   virtual void finalize() override {}
 
 protected:
-  MFEMVectorCoefficient * _vec_coef;
-  hephaestus::VectorDirichletBC _boundary_condition;
+  MFEMVectorCoefficient * _vec_coef{nullptr};
 };

--- a/include/bcs/MFEMVectorNormalIntegratedBC.h
+++ b/include/bcs/MFEMVectorNormalIntegratedBC.h
@@ -10,14 +10,12 @@ public:
   static InputParameters validParams();
 
   MFEMVectorNormalIntegratedBC(const InputParameters & parameters);
-  virtual ~MFEMVectorNormalIntegratedBC();
+  ~MFEMVectorNormalIntegratedBC() override {}
 
-  virtual hephaestus::BoundaryCondition * getBC() override;
   virtual void execute() override {}
   virtual void initialize() override {}
   virtual void finalize() override {}
 
 protected:
-  MFEMVectorCoefficient * _vec_coef;
-  hephaestus::IntegratedBC _boundary_condition;
+  MFEMVectorCoefficient * _vec_coef{nullptr};
 };

--- a/include/formulations/AFormulation.h
+++ b/include/formulations/AFormulation.h
@@ -29,12 +29,13 @@ public:
   virtual void execute() override {}
   virtual void initialize() override {}
   virtual void finalize() override {}
-  virtual hephaestus::ProblemBuilder * getProblemBuilder() override { return &formulation; };
+
+  std::shared_ptr<hephaestus::ProblemBuilder> getProblemBuilder() override { return formulation; }
 
 private:
   std::string magnetic_vector_potential_name;
   std::string magnetic_permeability_name;
   std::string electric_conductivity_name;
   std::string magnetic_reluctivity_name;
-  hephaestus::AFormulation formulation;
+  std::shared_ptr<hephaestus::AFormulation> formulation{nullptr};
 };

--- a/include/formulations/AVFormulation.h
+++ b/include/formulations/AVFormulation.h
@@ -42,7 +42,8 @@ public:
   virtual void execute() override {}
   virtual void initialize() override {}
   virtual void finalize() override {}
-  virtual hephaestus::ProblemBuilder * getProblemBuilder() override { return &formulation; };
+
+  std::shared_ptr<hephaestus::ProblemBuilder> getProblemBuilder() override { return formulation; }
 
 private:
   std::string magnetic_vector_potential_name;
@@ -50,5 +51,5 @@ private:
   std::string magnetic_permeability_name;
   std::string electric_conductivity_name;
   std::string magnetic_reluctivity_name;
-  hephaestus::AVFormulation formulation;
+  std::shared_ptr<hephaestus::AVFormulation> formulation{nullptr};
 };

--- a/include/formulations/ComplexAFormulation.h
+++ b/include/formulations/ComplexAFormulation.h
@@ -36,7 +36,8 @@ public:
   virtual void execute() override {}
   virtual void initialize() override {}
   virtual void finalize() override {}
-  virtual hephaestus::ProblemBuilder * getProblemBuilder() override { return &formulation; };
+
+  std::shared_ptr<hephaestus::ProblemBuilder> getProblemBuilder() override { return formulation; }
 
 private:
   std::string magnetic_vector_potential_name;
@@ -47,5 +48,5 @@ private:
   std::string electric_conductivity_name;
   std::string dielectric_permittivity_name;
   std::string magnetic_reluctivity_name;
-  hephaestus::ComplexAFormulation formulation;
+  std::shared_ptr<hephaestus::ComplexAFormulation> formulation{nullptr};
 };

--- a/include/formulations/ComplexEFormulation.h
+++ b/include/formulations/ComplexEFormulation.h
@@ -36,7 +36,8 @@ public:
   virtual void execute() override {}
   virtual void initialize() override {}
   virtual void finalize() override {}
-  virtual hephaestus::ProblemBuilder * getProblemBuilder() override { return &formulation; };
+
+  std::shared_ptr<hephaestus::ProblemBuilder> getProblemBuilder() override { return formulation; }
 
 private:
   std::string e_field_name;
@@ -47,5 +48,5 @@ private:
   std::string electric_conductivity_name;
   std::string dielectric_permittivity_name;
   std::string magnetic_reluctivity_name;
-  hephaestus::ComplexEFormulation formulation;
+  std::shared_ptr<hephaestus::ComplexEFormulation> formulation{nullptr};
 };

--- a/include/formulations/CustomFormulation.h
+++ b/include/formulations/CustomFormulation.h
@@ -14,8 +14,9 @@ public:
   virtual void execute() override {}
   virtual void initialize() override {}
   virtual void finalize() override {}
-  virtual hephaestus::ProblemBuilder * getProblemBuilder() override { return &formulation; };
+
+  std::shared_ptr<hephaestus::ProblemBuilder> getProblemBuilder() override { return formulation; }
 
 private:
-  hephaestus::TimeDomainEMFormulation formulation;
+  std::shared_ptr<hephaestus::TimeDomainEMFormulation> formulation{nullptr};
 };

--- a/include/formulations/EBFormulation.h
+++ b/include/formulations/EBFormulation.h
@@ -46,7 +46,8 @@ public:
   virtual void execute() override {}
   virtual void initialize() override {}
   virtual void finalize() override {}
-  virtual hephaestus::ProblemBuilder * getProblemBuilder() override { return &formulation; };
+
+  std::shared_ptr<hephaestus::ProblemBuilder> getProblemBuilder() override { return formulation; }
 
 private:
   std::string e_field_name;
@@ -54,5 +55,5 @@ private:
   std::string magnetic_permeability_name;
   std::string electric_conductivity_name;
   std::string magnetic_reluctivity_name;
-  hephaestus::EBDualFormulation formulation;
+  std::shared_ptr<hephaestus::EBDualFormulation> formulation{nullptr};
 };

--- a/include/formulations/EFormulation.h
+++ b/include/formulations/EFormulation.h
@@ -29,12 +29,13 @@ public:
   virtual void execute() override {}
   virtual void initialize() override {}
   virtual void finalize() override {}
-  virtual hephaestus::ProblemBuilder * getProblemBuilder() override { return &formulation; };
+
+  std::shared_ptr<hephaestus::ProblemBuilder> getProblemBuilder() override { return formulation; };
 
 private:
   std::string e_field_name;
   std::string magnetic_permeability_name;
   std::string electric_conductivity_name;
   std::string magnetic_reluctivity_name;
-  hephaestus::EFormulation formulation;
+  std::shared_ptr<hephaestus::EFormulation> formulation{nullptr};
 };

--- a/include/formulations/HFormulation.h
+++ b/include/formulations/HFormulation.h
@@ -28,12 +28,13 @@ public:
   virtual void execute() override {}
   virtual void initialize() override {}
   virtual void finalize() override {}
-  virtual hephaestus::ProblemBuilder * getProblemBuilder() override { return &formulation; };
+
+  std::shared_ptr<hephaestus::ProblemBuilder> getProblemBuilder() override { return formulation; };
 
 private:
   std::string magnetic_field_name;
   std::string magnetic_permeability_name;
   std::string electric_conductivity_name;
   std::string electric_resistivity_name;
-  hephaestus::HFormulation formulation;
+  std::shared_ptr<hephaestus::HFormulation> formulation{nullptr};
 };

--- a/include/formulations/MFEMFormulation.h
+++ b/include/formulations/MFEMFormulation.h
@@ -14,9 +14,10 @@ public:
   virtual void execute() override {}
   virtual void initialize() override {}
   virtual void finalize() override {}
-  virtual hephaestus::ProblemBuilder * getProblemBuilder()
+
+  virtual std::shared_ptr<hephaestus::ProblemBuilder> getProblemBuilder()
   {
     mooseError(
         "Base class MFEMFormulation cannot return a valid ProblemBuilder. Use a child class.");
-  };
+  }
 };

--- a/include/formulations/MagnetostaticFormulation.h
+++ b/include/formulations/MagnetostaticFormulation.h
@@ -26,11 +26,12 @@ public:
   virtual void execute() override {}
   virtual void initialize() override {}
   virtual void finalize() override {}
-  virtual hephaestus::ProblemBuilder * getProblemBuilder() override { return &formulation; };
+
+  std::shared_ptr<hephaestus::ProblemBuilder> getProblemBuilder() override { return formulation; }
 
 private:
   std::string magnetic_vector_potential_name;
   std::string magnetic_permeability_name;
   std::string magnetic_reluctivity_name;
-  hephaestus::MagnetostaticFormulation formulation;
+  std::shared_ptr<hephaestus::MagnetostaticFormulation> formulation{nullptr};
 };

--- a/include/kernels/MFEMBilinearFormKernel.h
+++ b/include/kernels/MFEMBilinearFormKernel.h
@@ -16,5 +16,5 @@ public:
   virtual void initialize() override {}
   virtual void finalize() override {}
 
-  virtual hephaestus::Kernel<mfem::ParBilinearForm> * getKernel() { return nullptr; };
+  virtual std::shared_ptr<hephaestus::Kernel<mfem::ParBilinearForm>> getKernel() { return nullptr; }
 };

--- a/include/kernels/MFEMDiffusionKernel.h
+++ b/include/kernels/MFEMDiffusionKernel.h
@@ -14,10 +14,9 @@ public:
   virtual void initialize() override {}
   virtual void finalize() override {}
 
-  // NB: unique pointer releases ownership when called. Caller is responsible for deleting kernel.
-  hephaestus::Kernel<mfem::ParBilinearForm> * getKernel() override;
+  std::shared_ptr<hephaestus::Kernel<mfem::ParBilinearForm>> getKernel() override { return _kernel; }
 
 protected:
   hephaestus::InputParameters _kernel_params;
-  std::unique_ptr<hephaestus::DiffusionKernel> _kernel{nullptr};
+  std::shared_ptr<hephaestus::DiffusionKernel> _kernel{nullptr};
 };

--- a/include/kernels/MFEMLinearFormKernel.h
+++ b/include/kernels/MFEMLinearFormKernel.h
@@ -16,5 +16,5 @@ public:
   virtual void initialize() override {}
   virtual void finalize() override {}
 
-  virtual hephaestus::Kernel<mfem::ParLinearForm> * getKernel() { return nullptr; };
+  virtual std::shared_ptr<hephaestus::Kernel<mfem::ParLinearForm>> getKernel() { return nullptr; }
 };

--- a/include/outputs/MFEMDataCollection.h
+++ b/include/outputs/MFEMDataCollection.h
@@ -11,10 +11,9 @@ public:
   static InputParameters validParams();
 
   MFEMDataCollection(const InputParameters & parameters);
-  virtual mfem::DataCollection * createDataCollection(const std::string & collection_name)
-  {
-    return new mfem::DataCollection(collection_name);
-  }
+
+  virtual std::shared_ptr<mfem::DataCollection>
+  createDataCollection(const std::string & collection_name) const;
 
 protected:
   void output() override {}

--- a/include/outputs/MFEMParaViewDataCollection.h
+++ b/include/outputs/MFEMParaViewDataCollection.h
@@ -11,8 +11,9 @@ public:
   static InputParameters validParams();
 
   MFEMParaViewDataCollection(const InputParameters & parameters);
-  virtual mfem::ParaViewDataCollection *
-  createDataCollection(const std::string & collection_name) override;
+
+  std::shared_ptr<mfem::DataCollection>
+  createDataCollection(const std::string & collection_name) const override;
 
 protected:
   bool _high_order_output;

--- a/include/outputs/MFEMVisItDataCollection.h
+++ b/include/outputs/MFEMVisItDataCollection.h
@@ -11,8 +11,9 @@ public:
   static InputParameters validParams();
 
   MFEMVisItDataCollection(const InputParameters & parameters);
-  virtual mfem::VisItDataCollection *
-  createDataCollection(const std::string & collection_name) override;
+
+  std::shared_ptr<mfem::DataCollection>
+  createDataCollection(const std::string & collection_name) const override;
 
 protected:
   bool _high_order_output;

--- a/include/problem/MFEMProblem.h
+++ b/include/problem/MFEMProblem.h
@@ -162,7 +162,8 @@ protected:
   hephaestus::InputParameters _solver_options;
   hephaestus::Outputs _outputs;
   hephaestus::InputParameters _exec_params;
-  hephaestus::ProblemBuilder * mfem_problem_builder;
+
+  std::shared_ptr<hephaestus::ProblemBuilder> mfem_problem_builder{nullptr};
 
   std::unique_ptr<hephaestus::Problem> mfem_problem;
   std::unique_ptr<hephaestus::Executioner> executioner;

--- a/include/sources/MFEMClosedCoilSource.h
+++ b/include/sources/MFEMClosedCoilSource.h
@@ -9,13 +9,11 @@ public:
   static InputParameters validParams();
 
   MFEMClosedCoilSource(const InputParameters & parameters);
-  virtual ~MFEMClosedCoilSource();
+  virtual ~MFEMClosedCoilSource() override {}
 
   virtual void execute() override {}
   virtual void initialize() override {}
   virtual void finalize() override {}
-
-  virtual void storeCoefficients(hephaestus::Coefficients & coefficients) override;
 
 protected:
   const MFEMVariable & _source_current_density_dual_gridfunction;

--- a/include/sources/MFEMClosedCoilSource.h
+++ b/include/sources/MFEMClosedCoilSource.h
@@ -15,7 +15,6 @@ public:
   virtual void initialize() override {}
   virtual void finalize() override {}
 
-  virtual hephaestus::Source * getSource() override;
   virtual void storeCoefficients(hephaestus::Coefficients & coefficients) override;
 
 protected:

--- a/include/sources/MFEMDivFreeVolumetricSource.h
+++ b/include/sources/MFEMDivFreeVolumetricSource.h
@@ -8,7 +8,7 @@ public:
   static InputParameters validParams();
 
   MFEMDivFreeVolumetricSource(const InputParameters & parameters);
-  virtual ~MFEMDivFreeVolumetricSource();
+  virtual ~MFEMDivFreeVolumetricSource() override {}
 
   virtual void execute() override {}
   virtual void initialize() override {}

--- a/include/sources/MFEMDivFreeVolumetricSource.h
+++ b/include/sources/MFEMDivFreeVolumetricSource.h
@@ -14,7 +14,6 @@ public:
   virtual void initialize() override {}
   virtual void finalize() override {}
 
-  virtual hephaestus::Source * getSource() override;
   virtual void storeCoefficients(hephaestus::Coefficients & coefficients) override;
 
 protected:

--- a/include/sources/MFEMDivFreeVolumetricSource.h
+++ b/include/sources/MFEMDivFreeVolumetricSource.h
@@ -24,5 +24,5 @@ protected:
   const MFEMFESpace & hcurl_fespace;
   const MFEMFESpace & h1_fespace;
 
-  mfem::PWVectorCoefficient * _restricted_coef;
+  std::shared_ptr<mfem::PWVectorCoefficient> _restricted_coef{nullptr};
 };

--- a/include/sources/MFEMOpenCoilSource.h
+++ b/include/sources/MFEMOpenCoilSource.h
@@ -9,7 +9,7 @@ public:
   static InputParameters validParams();
 
   MFEMOpenCoilSource(const InputParameters & parameters);
-  virtual ~MFEMOpenCoilSource();
+  virtual ~MFEMOpenCoilSource() override {}
 
   virtual void execute() override {}
   virtual void initialize() override {}

--- a/include/sources/MFEMOpenCoilSource.h
+++ b/include/sources/MFEMOpenCoilSource.h
@@ -15,8 +15,6 @@ public:
   virtual void initialize() override {}
   virtual void finalize() override {}
 
-  virtual void storeCoefficients(hephaestus::Coefficients & coefficients) override;
-
 protected:
   const MFEMVariable & _source_current_density_gridfunction;
   const MFEMVariable & _source_potential_gridfunction;

--- a/include/sources/MFEMOpenCoilSource.h
+++ b/include/sources/MFEMOpenCoilSource.h
@@ -15,7 +15,6 @@ public:
   virtual void initialize() override {}
   virtual void finalize() override {}
 
-  virtual hephaestus::Source * getSource() override;
   virtual void storeCoefficients(hephaestus::Coefficients & coefficients) override;
 
 protected:

--- a/include/sources/MFEMScalarPotentialSource.h
+++ b/include/sources/MFEMScalarPotentialSource.h
@@ -7,7 +7,7 @@ public:
   static InputParameters validParams();
 
   MFEMScalarPotentialSource(const InputParameters & parameters);
-  virtual ~MFEMScalarPotentialSource();
+  virtual ~MFEMScalarPotentialSource() override {}
 
   virtual void execute() override {}
   virtual void initialize() override {}

--- a/include/sources/MFEMScalarPotentialSource.h
+++ b/include/sources/MFEMScalarPotentialSource.h
@@ -13,8 +13,6 @@ public:
   virtual void initialize() override {}
   virtual void finalize() override {}
 
-  virtual void storeCoefficients(hephaestus::Coefficients & coefficients) override;
-
 protected:
   std::string source_coef_name;
   std::string potential_name;
@@ -22,6 +20,4 @@ protected:
   std::string conductivity_coef_name;
   const MFEMFESpace & hcurl_fespace;
   const MFEMFESpace & h1_fespace;
-
-  mfem::PWVectorCoefficient * _restricted_coef;
 };

--- a/include/sources/MFEMScalarPotentialSource.h
+++ b/include/sources/MFEMScalarPotentialSource.h
@@ -13,7 +13,6 @@ public:
   virtual void initialize() override {}
   virtual void finalize() override {}
 
-  virtual hephaestus::Source * getSource() override;
   virtual void storeCoefficients(hephaestus::Coefficients & coefficients) override;
 
 protected:

--- a/include/sources/MFEMSource.h
+++ b/include/sources/MFEMSource.h
@@ -19,10 +19,11 @@ public:
   virtual void initialize() override {}
   virtual void finalize() override {}
 
-  virtual hephaestus::Source * getSource();
+  virtual std::shared_ptr<hephaestus::Source> getSource() { return _source; }
+
   virtual void storeCoefficients(hephaestus::Coefficients & coefficients);
 
 protected:
   std::vector<SubdomainID> blocks;
-  hephaestus::Source * _source;
+  std::shared_ptr<hephaestus::Source> _source{nullptr};
 };

--- a/src/auxkernels/MFEMAuxSolver.C
+++ b/src/auxkernels/MFEMAuxSolver.C
@@ -16,10 +16,4 @@ MFEMAuxSolver::validParams()
 
 MFEMAuxSolver::MFEMAuxSolver(const InputParameters & parameters) : GeneralUserObject(parameters) {}
 
-hephaestus::AuxSolver *
-MFEMAuxSolver::getAuxSolver()
-{
-  return _auxsolver;
-}
-
 MFEMAuxSolver::~MFEMAuxSolver() {}

--- a/src/auxkernels/MFEMJouleHeatingAux.C
+++ b/src/auxkernels/MFEMJouleHeatingAux.C
@@ -23,7 +23,7 @@ void
 MFEMJouleHeatingAux::storeCoefficients(hephaestus::Coefficients & coefficients)
 {
   std::string coef_name = std::string("JouleHeating");
-  coefficients.scalars.Register(coef_name, joule_heating_aux);
+  coefficients._scalars.Register(coef_name, joule_heating_aux);
 }
 
 MFEMJouleHeatingAux::~MFEMJouleHeatingAux() {}

--- a/src/auxkernels/MFEMJouleHeatingAux.C
+++ b/src/auxkernels/MFEMJouleHeatingAux.C
@@ -15,21 +15,15 @@ MFEMJouleHeatingAux::MFEMJouleHeatingAux(const InputParameters & parameters)
     joule_heating_params({{"CoupledVariableName", std::string("electric_field")},
                           {"ConductivityCoefName", std::string("electrical_conductivity")},
                           {"JouleHeatingVarName", std::string("joule_heating")}}),
-    joule_heating_aux(joule_heating_params)
+    joule_heating_aux(std::make_shared<JouleHeatingCoefficient>(joule_heating_params))
 {
-}
-
-hephaestus::AuxSolver *
-MFEMJouleHeatingAux::getAuxSolver()
-{
-  return &joule_heating_aux;
 }
 
 void
 MFEMJouleHeatingAux::storeCoefficients(hephaestus::Coefficients & coefficients)
 {
   std::string coef_name = std::string("JouleHeating");
-  coefficients.scalars.Register(coef_name, &joule_heating_aux, false);
+  coefficients.scalars.Register(coef_name, joule_heating_aux);
 }
 
 MFEMJouleHeatingAux::~MFEMJouleHeatingAux() {}

--- a/src/bcs/MFEMBoundaryCondition.C
+++ b/src/bcs/MFEMBoundaryCondition.C
@@ -27,13 +27,5 @@ MFEMBoundaryCondition::MFEMBoundaryCondition(const InputParameters & parameters)
     bdr_attr[i] = std::stoi(_boundary_names[i]);
   }
   _boundary_condition =
-      new hephaestus::BoundaryCondition(getParam<std::string>("variable"), bdr_attr);
+      std::make_shared<hephaestus::BoundaryCondition>(getParam<std::string>("variable"), bdr_attr);
 }
-
-hephaestus::BoundaryCondition *
-MFEMBoundaryCondition::getBC()
-{
-  return _boundary_condition;
-}
-
-MFEMBoundaryCondition::~MFEMBoundaryCondition() { delete _boundary_condition; }

--- a/src/bcs/MFEMComplexVectorDirichletBC.C
+++ b/src/bcs/MFEMComplexVectorDirichletBC.C
@@ -23,18 +23,11 @@ MFEMComplexVectorDirichletBC::MFEMComplexVectorDirichletBC(const InputParameters
     _vec_coef_re(const_cast<MFEMVectorCoefficient *>(
         &getUserObject<MFEMVectorCoefficient>("real_vector_coefficient"))),
     _vec_coef_im(const_cast<MFEMVectorCoefficient *>(
-        &getUserObject<MFEMVectorCoefficient>("imag_vector_coefficient"))),
-    _boundary_condition(getParam<std::string>("variable"),
-                        bdr_attr,
-                        _vec_coef_re->getVectorCoefficient(),
-                        _vec_coef_im->getVectorCoefficient())
+        &getUserObject<MFEMVectorCoefficient>("imag_vector_coefficient")))
 {
+  _boundary_condition =
+      std::make_shared<hephaestus::VectorDirichletBC>(getParam<std::string>("variable"),
+                                                      bdr_attr,
+                                                      _vec_coef_re->getVectorCoefficient(),
+                                                      _vec_coef_im->getVectorCoefficient());
 }
-
-hephaestus::BoundaryCondition *
-MFEMComplexVectorDirichletBC::getBC()
-{
-  return &_boundary_condition;
-}
-
-MFEMComplexVectorDirichletBC::~MFEMComplexVectorDirichletBC() {}

--- a/src/bcs/MFEMRWTE10PortRBC.C
+++ b/src/bcs/MFEMRWTE10PortRBC.C
@@ -31,14 +31,6 @@ MFEMRWTE10PortRBC::MFEMRWTE10PortRBC(const InputParameters & parameters)
     _wv{_port_width_vector(0), _port_width_vector(1), _port_width_vector(2)},
     _input_port(getParam<bool>("input_port"))
 {
-  _boundary_condition = new hephaestus::RWTE10PortRBC(
+  _boundary_condition = std::make_shared<hephaestus::RWTE10PortRBC>(
       getParam<std::string>("variable"), bdr_attr, _frequency, _lv, _wv, _input_port);
 }
-
-hephaestus::BoundaryCondition *
-MFEMRWTE10PortRBC::getBC()
-{
-  return _boundary_condition;
-}
-
-MFEMRWTE10PortRBC::~MFEMRWTE10PortRBC() {}

--- a/src/bcs/MFEMScalarDirichletBC.C
+++ b/src/bcs/MFEMScalarDirichletBC.C
@@ -13,13 +13,8 @@ MFEMScalarDirichletBC::validParams()
 
 MFEMScalarDirichletBC::MFEMScalarDirichletBC(const InputParameters & parameters)
   : MFEMBoundaryCondition(parameters),
-    _coef(const_cast<MFEMCoefficient *>(&getUserObject<MFEMCoefficient>("coefficient"))),
-    _boundary_condition(getParam<std::string>("variable"), bdr_attr, _coef->getCoefficient())
+    _coef(const_cast<MFEMCoefficient *>(&getUserObject<MFEMCoefficient>("coefficient")))
 {
-}
-
-hephaestus::BoundaryCondition *
-MFEMScalarDirichletBC::getBC()
-{
-  return &_boundary_condition;
+  _boundary_condition = std::make_shared<hephaestus::ScalarDirichletBC>(
+      getParam<std::string>("variable"), bdr_attr, _coef->getCoefficient());
 }

--- a/src/bcs/MFEMVectorDirichletBC.C
+++ b/src/bcs/MFEMVectorDirichletBC.C
@@ -15,16 +15,8 @@ MFEMVectorDirichletBC::validParams()
 MFEMVectorDirichletBC::MFEMVectorDirichletBC(const InputParameters & parameters)
   : MFEMBoundaryCondition(parameters),
     _vec_coef(const_cast<MFEMVectorCoefficient *>(
-        &getUserObject<MFEMVectorCoefficient>("vector_coefficient"))),
-    _boundary_condition(
-        getParam<std::string>("variable"), bdr_attr, _vec_coef->getVectorCoefficient())
+        &getUserObject<MFEMVectorCoefficient>("vector_coefficient")))
 {
+  _boundary_condition = std::make_shared<hephaestus::VectorDirichletBC>(
+      getParam<std::string>("variable"), bdr_attr, _vec_coef->getVectorCoefficient());
 }
-
-hephaestus::BoundaryCondition *
-MFEMVectorDirichletBC::getBC()
-{
-  return &_boundary_condition;
-}
-
-MFEMVectorDirichletBC::~MFEMVectorDirichletBC() {}

--- a/src/bcs/MFEMVectorNormalIntegratedBC.C
+++ b/src/bcs/MFEMVectorNormalIntegratedBC.C
@@ -16,17 +16,10 @@ MFEMVectorNormalIntegratedBC::validParams()
 MFEMVectorNormalIntegratedBC::MFEMVectorNormalIntegratedBC(const InputParameters & parameters)
   : MFEMBoundaryCondition(parameters),
     _vec_coef(const_cast<MFEMVectorCoefficient *>(
-        &getUserObject<MFEMVectorCoefficient>("vector_coefficient"))),
-    _boundary_condition(getParam<std::string>("variable"),
-                        bdr_attr,
-                        new mfem::BoundaryNormalLFIntegrator(*_vec_coef->getVectorCoefficient()))
+        &getUserObject<MFEMVectorCoefficient>("vector_coefficient")))
 {
+  _boundary_condition = std::make_shared<hephaestus::IntegratedBC>(
+      getParam<std::string>("variable"),
+      bdr_attr,
+      new mfem::BoundaryNormalLFIntegrator(*_vec_coef->getVectorCoefficient()));
 }
-
-hephaestus::BoundaryCondition *
-MFEMVectorNormalIntegratedBC::getBC()
-{
-  return &_boundary_condition;
-}
-
-MFEMVectorNormalIntegratedBC::~MFEMVectorNormalIntegratedBC() {}

--- a/src/coefficients/MFEMParsedCoefficientHelper.C
+++ b/src/coefficients/MFEMParsedCoefficientHelper.C
@@ -138,7 +138,7 @@ MFEMParsedCoefficientHelper::Init(const hephaestus::GridFunctions & variables,
   auto nmfem_coefs = _coefficient_names.size();
   for (MooseIndex(_coefficient_names) i = 0; i < nmfem_coefs; ++i)
   {
-    _coefficients[i] = coefficients.scalars.Get(_coefficient_names[i]);
+    _coefficients[i] = coefficients._scalars.Get(_coefficient_names[i]);
   }
 }
 

--- a/src/formulations/AFormulation.C
+++ b/src/formulations/AFormulation.C
@@ -43,28 +43,30 @@ AFormulation::AFormulation(const InputParameters & parameters)
     magnetic_vector_potential_name(getParam<std::string>("magnetic_vector_potential_name")),
     magnetic_permeability_name(getParam<std::string>("magnetic_permeability_name")),
     electric_conductivity_name(getParam<std::string>("electric_conductivity_name")),
-    magnetic_reluctivity_name(getParam<std::string>("magnetic_reluctivity_name")),
-    formulation(magnetic_reluctivity_name,
-                magnetic_permeability_name,
-                electric_conductivity_name,
-                magnetic_vector_potential_name)
+    magnetic_reluctivity_name(getParam<std::string>("magnetic_reluctivity_name"))
 {
+  formulation = std::make_shared<hephaestus::AFormulation>(magnetic_reluctivity_name,
+                                                           magnetic_permeability_name,
+                                                           electric_conductivity_name,
+                                                           magnetic_vector_potential_name);
+
   if (isParamValid("current_density_name"))
-    formulation.RegisterCurrentDensityAux(getParam<std::string>("current_density_name"));
+    formulation->RegisterCurrentDensityAux(getParam<std::string>("current_density_name"));
   if (isParamValid("magnetic_flux_density_name"))
-    formulation.RegisterMagneticFluxDensityAux(getParam<std::string>("magnetic_flux_density_name"));
+    formulation->RegisterMagneticFluxDensityAux(
+        getParam<std::string>("magnetic_flux_density_name"));
   if (isParamValid("electric_field_name"))
-    formulation.RegisterElectricFieldAux(getParam<std::string>("electric_field_name"));
+    formulation->RegisterElectricFieldAux(getParam<std::string>("electric_field_name"));
   if (isParamValid("magnetic_field_name"))
-    formulation.RegisterMagneticFieldAux(getParam<std::string>("magnetic_field_name"));
+    formulation->RegisterMagneticFieldAux(getParam<std::string>("magnetic_field_name"));
   if (isParamValid("lorentz_force_density_name"))
-    formulation.RegisterLorentzForceDensityAux(getParam<std::string>("lorentz_force_density_name"),
-                                               getParam<std::string>("magnetic_flux_density_name"),
-                                               getParam<std::string>("current_density_name"));
+    formulation->RegisterLorentzForceDensityAux(getParam<std::string>("lorentz_force_density_name"),
+                                                getParam<std::string>("magnetic_flux_density_name"),
+                                                getParam<std::string>("current_density_name"));
   if (isParamValid("joule_heating_density_name"))
-    formulation.RegisterJouleHeatingDensityAux(getParam<std::string>("joule_heating_density_name"),
-                                               getParam<std::string>("electric_field_name"),
-                                               electric_conductivity_name);
+    formulation->RegisterJouleHeatingDensityAux(getParam<std::string>("joule_heating_density_name"),
+                                                getParam<std::string>("electric_field_name"),
+                                                electric_conductivity_name);
 }
 
 AFormulation::~AFormulation() {}

--- a/src/formulations/AFormulation.C
+++ b/src/formulations/AFormulation.C
@@ -50,19 +50,19 @@ AFormulation::AFormulation(const InputParameters & parameters)
                 magnetic_vector_potential_name)
 {
   if (isParamValid("current_density_name"))
-    formulation.registerCurrentDensityAux(getParam<std::string>("current_density_name"));
+    formulation.RegisterCurrentDensityAux(getParam<std::string>("current_density_name"));
   if (isParamValid("magnetic_flux_density_name"))
-    formulation.registerMagneticFluxDensityAux(getParam<std::string>("magnetic_flux_density_name"));
+    formulation.RegisterMagneticFluxDensityAux(getParam<std::string>("magnetic_flux_density_name"));
   if (isParamValid("electric_field_name"))
-    formulation.registerElectricFieldAux(getParam<std::string>("electric_field_name"));
+    formulation.RegisterElectricFieldAux(getParam<std::string>("electric_field_name"));
   if (isParamValid("magnetic_field_name"))
-    formulation.registerMagneticFieldAux(getParam<std::string>("magnetic_field_name"));
+    formulation.RegisterMagneticFieldAux(getParam<std::string>("magnetic_field_name"));
   if (isParamValid("lorentz_force_density_name"))
-    formulation.registerLorentzForceDensityAux(getParam<std::string>("lorentz_force_density_name"),
+    formulation.RegisterLorentzForceDensityAux(getParam<std::string>("lorentz_force_density_name"),
                                                getParam<std::string>("magnetic_flux_density_name"),
                                                getParam<std::string>("current_density_name"));
   if (isParamValid("joule_heating_density_name"))
-    formulation.registerJouleHeatingDensityAux(getParam<std::string>("joule_heating_density_name"),
+    formulation.RegisterJouleHeatingDensityAux(getParam<std::string>("joule_heating_density_name"),
                                                getParam<std::string>("electric_field_name"),
                                                electric_conductivity_name);
 }

--- a/src/formulations/AVFormulation.C
+++ b/src/formulations/AVFormulation.C
@@ -28,13 +28,13 @@ AVFormulation::AVFormulation(const InputParameters & parameters)
     electric_potential_name(getParam<std::string>("electric_potential_name")),
     magnetic_permeability_name(getParam<std::string>("magnetic_permeability_name")),
     electric_conductivity_name(getParam<std::string>("electric_conductivity_name")),
-    magnetic_reluctivity_name(getParam<std::string>("magnetic_reluctivity_name")),
-    formulation(magnetic_reluctivity_name,
-                magnetic_permeability_name,
-                electric_conductivity_name,
-                magnetic_vector_potential_name,
-                electric_potential_name)
+    magnetic_reluctivity_name(getParam<std::string>("magnetic_reluctivity_name"))
 {
+  formulation = std::make_shared<hephaestus::AVFormulation>(magnetic_reluctivity_name,
+                                                            magnetic_permeability_name,
+                                                            electric_conductivity_name,
+                                                            magnetic_vector_potential_name,
+                                                            electric_potential_name);
 }
 
 AVFormulation::~AVFormulation() {}

--- a/src/formulations/ComplexAFormulation.C
+++ b/src/formulations/ComplexAFormulation.C
@@ -70,18 +70,18 @@ ComplexAFormulation::ComplexAFormulation(const InputParameters & parameters)
                 magnetic_vector_potential_im_name)
 {
   if (isParamValid("current_density_re_name") && isParamValid("current_density_im_name"))
-    formulation.registerCurrentDensityAux(getParam<std::string>("current_density_re_name"),
+    formulation.RegisterCurrentDensityAux(getParam<std::string>("current_density_re_name"),
                                           getParam<std::string>("current_density_im_name"));
   if (isParamValid("magnetic_flux_density_re_name") &&
       isParamValid("magnetic_flux_density_im_name"))
-    formulation.registerMagneticFluxDensityAux(
+    formulation.RegisterMagneticFluxDensityAux(
         getParam<std::string>("magnetic_flux_density_re_name"),
         getParam<std::string>("magnetic_flux_density_im_name"));
   if (isParamValid("electric_field_re_name") && isParamValid("electric_field_im_name"))
-    formulation.registerElectricFieldAux(getParam<std::string>("electric_field_re_name"),
+    formulation.RegisterElectricFieldAux(getParam<std::string>("electric_field_re_name"),
                                          getParam<std::string>("electric_field_im_name"));
   if (isParamValid("joule_heating_density_name"))
-    formulation.registerJouleHeatingDensityAux(getParam<std::string>("joule_heating_density_name"),
+    formulation.RegisterJouleHeatingDensityAux(getParam<std::string>("joule_heating_density_name"),
                                                getParam<std::string>("electric_field_re_name"),
                                                getParam<std::string>("electric_field_im_name"),
                                                electric_conductivity_name);

--- a/src/formulations/ComplexAFormulation.C
+++ b/src/formulations/ComplexAFormulation.C
@@ -60,31 +60,33 @@ ComplexAFormulation::ComplexAFormulation(const InputParameters & parameters)
     magnetic_permeability_name(getParam<std::string>("magnetic_permeability_name")),
     electric_conductivity_name(getParam<std::string>("electric_conductivity_name")),
     dielectric_permittivity_name(getParam<std::string>("dielectric_permittivity_name")),
-    magnetic_reluctivity_name(getParam<std::string>("magnetic_reluctivity_name")),
-    formulation(magnetic_reluctivity_name,
-                electric_conductivity_name,
-                dielectric_permittivity_name,
-                frequency_name,
-                magnetic_vector_potential_name,
-                magnetic_vector_potential_re_name,
-                magnetic_vector_potential_im_name)
+    magnetic_reluctivity_name(getParam<std::string>("magnetic_reluctivity_name"))
 {
+  formulation =
+      std::make_shared<hephaestus::ComplexAFormulation>(magnetic_reluctivity_name,
+                                                        electric_conductivity_name,
+                                                        dielectric_permittivity_name,
+                                                        frequency_name,
+                                                        magnetic_vector_potential_name,
+                                                        magnetic_vector_potential_re_name,
+                                                        magnetic_vector_potential_im_name);
+
   if (isParamValid("current_density_re_name") && isParamValid("current_density_im_name"))
-    formulation.RegisterCurrentDensityAux(getParam<std::string>("current_density_re_name"),
-                                          getParam<std::string>("current_density_im_name"));
+    formulation->RegisterCurrentDensityAux(getParam<std::string>("current_density_re_name"),
+                                           getParam<std::string>("current_density_im_name"));
   if (isParamValid("magnetic_flux_density_re_name") &&
       isParamValid("magnetic_flux_density_im_name"))
-    formulation.RegisterMagneticFluxDensityAux(
+    formulation->RegisterMagneticFluxDensityAux(
         getParam<std::string>("magnetic_flux_density_re_name"),
         getParam<std::string>("magnetic_flux_density_im_name"));
   if (isParamValid("electric_field_re_name") && isParamValid("electric_field_im_name"))
-    formulation.RegisterElectricFieldAux(getParam<std::string>("electric_field_re_name"),
-                                         getParam<std::string>("electric_field_im_name"));
+    formulation->RegisterElectricFieldAux(getParam<std::string>("electric_field_re_name"),
+                                          getParam<std::string>("electric_field_im_name"));
   if (isParamValid("joule_heating_density_name"))
-    formulation.RegisterJouleHeatingDensityAux(getParam<std::string>("joule_heating_density_name"),
-                                               getParam<std::string>("electric_field_re_name"),
-                                               getParam<std::string>("electric_field_im_name"),
-                                               electric_conductivity_name);
+    formulation->RegisterJouleHeatingDensityAux(getParam<std::string>("joule_heating_density_name"),
+                                                getParam<std::string>("electric_field_re_name"),
+                                                getParam<std::string>("electric_field_im_name"),
+                                                electric_conductivity_name);
 }
 
 ComplexAFormulation::~ComplexAFormulation() {}

--- a/src/formulations/ComplexEFormulation.C
+++ b/src/formulations/ComplexEFormulation.C
@@ -53,28 +53,29 @@ ComplexEFormulation::ComplexEFormulation(const InputParameters & parameters)
     magnetic_permeability_name(getParam<std::string>("magnetic_permeability_name")),
     electric_conductivity_name(getParam<std::string>("electric_conductivity_name")),
     dielectric_permittivity_name(getParam<std::string>("dielectric_permittivity_name")),
-    magnetic_reluctivity_name(getParam<std::string>("magnetic_reluctivity_name")),
-    formulation(magnetic_reluctivity_name,
-                electric_conductivity_name,
-                dielectric_permittivity_name,
-                frequency_name,
-                e_field_name,
-                e_field_re_name,
-                e_field_im_name)
+    magnetic_reluctivity_name(getParam<std::string>("magnetic_reluctivity_name"))
 {
+  formulation = std::make_shared<hephaestus::ComplexEFormulation>(magnetic_reluctivity_name,
+                                                                  electric_conductivity_name,
+                                                                  dielectric_permittivity_name,
+                                                                  frequency_name,
+                                                                  e_field_name,
+                                                                  e_field_re_name,
+                                                                  e_field_im_name);
+
   if (isParamValid("current_density_re_name") && isParamValid("current_density_im_name"))
-    formulation.RegisterCurrentDensityAux(getParam<std::string>("current_density_re_name"),
-                                          getParam<std::string>("current_density_im_name"));
+    formulation->RegisterCurrentDensityAux(getParam<std::string>("current_density_re_name"),
+                                           getParam<std::string>("current_density_im_name"));
   if (isParamValid("magnetic_flux_density_re_name") &&
       isParamValid("magnetic_flux_density_im_name"))
-    formulation.RegisterMagneticFluxDensityAux(
+    formulation->RegisterMagneticFluxDensityAux(
         getParam<std::string>("magnetic_flux_density_re_name"),
         getParam<std::string>("magnetic_flux_density_im_name"));
   if (isParamValid("joule_heating_density_name"))
-    formulation.RegisterJouleHeatingDensityAux(getParam<std::string>("joule_heating_density_name"),
-                                               getParam<std::string>("e_field_re_name"),
-                                               getParam<std::string>("e_field_im_name"),
-                                               electric_conductivity_name);
+    formulation->RegisterJouleHeatingDensityAux(getParam<std::string>("joule_heating_density_name"),
+                                                getParam<std::string>("e_field_re_name"),
+                                                getParam<std::string>("e_field_im_name"),
+                                                electric_conductivity_name);
 }
 
 ComplexEFormulation::~ComplexEFormulation() {}

--- a/src/formulations/ComplexEFormulation.C
+++ b/src/formulations/ComplexEFormulation.C
@@ -63,15 +63,15 @@ ComplexEFormulation::ComplexEFormulation(const InputParameters & parameters)
                 e_field_im_name)
 {
   if (isParamValid("current_density_re_name") && isParamValid("current_density_im_name"))
-    formulation.registerCurrentDensityAux(getParam<std::string>("current_density_re_name"),
+    formulation.RegisterCurrentDensityAux(getParam<std::string>("current_density_re_name"),
                                           getParam<std::string>("current_density_im_name"));
   if (isParamValid("magnetic_flux_density_re_name") &&
       isParamValid("magnetic_flux_density_im_name"))
-    formulation.registerMagneticFluxDensityAux(
+    formulation.RegisterMagneticFluxDensityAux(
         getParam<std::string>("magnetic_flux_density_re_name"),
         getParam<std::string>("magnetic_flux_density_im_name"));
   if (isParamValid("joule_heating_density_name"))
-    formulation.registerJouleHeatingDensityAux(getParam<std::string>("joule_heating_density_name"),
+    formulation.RegisterJouleHeatingDensityAux(getParam<std::string>("joule_heating_density_name"),
                                                getParam<std::string>("e_field_re_name"),
                                                getParam<std::string>("e_field_im_name"),
                                                electric_conductivity_name);

--- a/src/formulations/CustomFormulation.C
+++ b/src/formulations/CustomFormulation.C
@@ -10,8 +10,9 @@ CustomFormulation::validParams()
 }
 
 CustomFormulation::CustomFormulation(const InputParameters & parameters)
-  : MFEMFormulation(parameters), formulation()
+  : MFEMFormulation(parameters)
 {
+  formulation = std::make_shared<hephaestus::TimeDomainEMFormulation>();
 }
 
 CustomFormulation::~CustomFormulation() {}

--- a/src/formulations/EBFormulation.C
+++ b/src/formulations/EBFormulation.C
@@ -37,23 +37,24 @@ EBFormulation::EBFormulation(const InputParameters & parameters)
     b_field_name(getParam<std::string>("b_field_name")),
     magnetic_permeability_name(getParam<std::string>("magnetic_permeability_name")),
     electric_conductivity_name(getParam<std::string>("electric_conductivity_name")),
-    magnetic_reluctivity_name(getParam<std::string>("magnetic_reluctivity_name")),
-    formulation(magnetic_reluctivity_name,
-                magnetic_permeability_name,
-                electric_conductivity_name,
-                e_field_name,
-                b_field_name)
+    magnetic_reluctivity_name(getParam<std::string>("magnetic_reluctivity_name"))
 {
+  formulation = std::make_shared<hephaestus::EBDualFormulation>(magnetic_reluctivity_name,
+                                                                magnetic_permeability_name,
+                                                                electric_conductivity_name,
+                                                                e_field_name,
+                                                                b_field_name);
+
   if (isParamValid("current_density_name"))
-    formulation.RegisterCurrentDensityAux(getParam<std::string>("current_density_name"));
+    formulation->RegisterCurrentDensityAux(getParam<std::string>("current_density_name"));
   if (isParamValid("lorentz_force_density_name"))
-    formulation.RegisterLorentzForceDensityAux(getParam<std::string>("lorentz_force_density_name"),
-                                               b_field_name,
-                                               getParam<std::string>("current_density_name"));
+    formulation->RegisterLorentzForceDensityAux(getParam<std::string>("lorentz_force_density_name"),
+                                                b_field_name,
+                                                getParam<std::string>("current_density_name"));
   if (isParamValid("joule_heating_density_name"))
-    formulation.RegisterJouleHeatingDensityAux(getParam<std::string>("joule_heating_density_name"),
-                                               e_field_name,
-                                               electric_conductivity_name);
+    formulation->RegisterJouleHeatingDensityAux(getParam<std::string>("joule_heating_density_name"),
+                                                e_field_name,
+                                                electric_conductivity_name);
 }
 
 EBFormulation::~EBFormulation() {}

--- a/src/formulations/EBFormulation.C
+++ b/src/formulations/EBFormulation.C
@@ -45,13 +45,13 @@ EBFormulation::EBFormulation(const InputParameters & parameters)
                 b_field_name)
 {
   if (isParamValid("current_density_name"))
-    formulation.registerCurrentDensityAux(getParam<std::string>("current_density_name"));
+    formulation.RegisterCurrentDensityAux(getParam<std::string>("current_density_name"));
   if (isParamValid("lorentz_force_density_name"))
-    formulation.registerLorentzForceDensityAux(getParam<std::string>("lorentz_force_density_name"),
+    formulation.RegisterLorentzForceDensityAux(getParam<std::string>("lorentz_force_density_name"),
                                                b_field_name,
                                                getParam<std::string>("current_density_name"));
   if (isParamValid("joule_heating_density_name"))
-    formulation.registerJouleHeatingDensityAux(getParam<std::string>("joule_heating_density_name"),
+    formulation.RegisterJouleHeatingDensityAux(getParam<std::string>("joule_heating_density_name"),
                                                e_field_name,
                                                electric_conductivity_name);
 }

--- a/src/formulations/EFormulation.C
+++ b/src/formulations/EFormulation.C
@@ -38,9 +38,9 @@ EFormulation::EFormulation(const InputParameters & parameters)
                 e_field_name)
 {
   if (isParamValid("current_density_name"))
-    formulation.registerCurrentDensityAux(getParam<std::string>("current_density_name"));
+    formulation.RegisterCurrentDensityAux(getParam<std::string>("current_density_name"));
   if (isParamValid("joule_heating_density_name"))
-    formulation.registerJouleHeatingDensityAux(getParam<std::string>("joule_heating_density_name"),
+    formulation.RegisterJouleHeatingDensityAux(getParam<std::string>("joule_heating_density_name"),
                                                e_field_name,
                                                electric_conductivity_name);
 }

--- a/src/formulations/EFormulation.C
+++ b/src/formulations/EFormulation.C
@@ -31,18 +31,19 @@ EFormulation::EFormulation(const InputParameters & parameters)
     e_field_name(getParam<std::string>("e_field_name")),
     magnetic_permeability_name(getParam<std::string>("magnetic_permeability_name")),
     electric_conductivity_name(getParam<std::string>("electric_conductivity_name")),
-    magnetic_reluctivity_name(getParam<std::string>("magnetic_reluctivity_name")),
-    formulation(magnetic_reluctivity_name,
-                magnetic_permeability_name,
-                electric_conductivity_name,
-                e_field_name)
+    magnetic_reluctivity_name(getParam<std::string>("magnetic_reluctivity_name"))
 {
+  formulation = std::make_shared<hephaestus::EFormulation>(magnetic_reluctivity_name,
+                                                           magnetic_permeability_name,
+                                                           electric_conductivity_name,
+                                                           e_field_name);
+
   if (isParamValid("current_density_name"))
-    formulation.RegisterCurrentDensityAux(getParam<std::string>("current_density_name"));
+    formulation->RegisterCurrentDensityAux(getParam<std::string>("current_density_name"));
   if (isParamValid("joule_heating_density_name"))
-    formulation.RegisterJouleHeatingDensityAux(getParam<std::string>("joule_heating_density_name"),
-                                               e_field_name,
-                                               electric_conductivity_name);
+    formulation->RegisterJouleHeatingDensityAux(getParam<std::string>("joule_heating_density_name"),
+                                                e_field_name,
+                                                electric_conductivity_name);
 }
 
 EFormulation::~EFormulation() {}

--- a/src/formulations/HFormulation.C
+++ b/src/formulations/HFormulation.C
@@ -47,17 +47,17 @@ HFormulation::HFormulation(const InputParameters & parameters)
                 magnetic_field_name)
 {
   if (isParamValid("current_density_name"))
-    formulation.registerCurrentDensityAux(getParam<std::string>("current_density_name"));
+    formulation.RegisterCurrentDensityAux(getParam<std::string>("current_density_name"));
   if (isParamValid("magnetic_flux_density_name"))
-    formulation.registerMagneticFluxDensityAux(getParam<std::string>("magnetic_flux_density_name"));
+    formulation.RegisterMagneticFluxDensityAux(getParam<std::string>("magnetic_flux_density_name"));
   if (isParamValid("electric_field_name"))
-    formulation.registerElectricFieldAux(getParam<std::string>("electric_field_name"));
+    formulation.RegisterElectricFieldAux(getParam<std::string>("electric_field_name"));
   if (isParamValid("lorentz_force_density_name"))
-    formulation.registerLorentzForceDensityAux(getParam<std::string>("lorentz_force_density_name"),
+    formulation.RegisterLorentzForceDensityAux(getParam<std::string>("lorentz_force_density_name"),
                                                getParam<std::string>("magnetic_flux_density_name"),
                                                getParam<std::string>("current_density_name"));
   if (isParamValid("joule_heating_density_name"))
-    formulation.registerJouleHeatingDensityAux(getParam<std::string>("joule_heating_density_name"),
+    formulation.RegisterJouleHeatingDensityAux(getParam<std::string>("joule_heating_density_name"),
                                                getParam<std::string>("electric_field_name"),
                                                electric_conductivity_name);
 }

--- a/src/formulations/HFormulation.C
+++ b/src/formulations/HFormulation.C
@@ -40,26 +40,28 @@ HFormulation::HFormulation(const InputParameters & parameters)
     magnetic_field_name(getParam<std::string>("magnetic_field_name")),
     magnetic_permeability_name(getParam<std::string>("magnetic_permeability_name")),
     electric_conductivity_name(getParam<std::string>("electric_conductivity_name")),
-    electric_resistivity_name(getParam<std::string>("electric_resistivity_name")),
-    formulation(electric_resistivity_name,
-                electric_conductivity_name,
-                magnetic_permeability_name,
-                magnetic_field_name)
+    electric_resistivity_name(getParam<std::string>("electric_resistivity_name"))
 {
+  formulation = std::make_shared<hephaestus::HFormulation>(electric_resistivity_name,
+                                                           electric_conductivity_name,
+                                                           magnetic_permeability_name,
+                                                           magnetic_field_name);
+
   if (isParamValid("current_density_name"))
-    formulation.RegisterCurrentDensityAux(getParam<std::string>("current_density_name"));
+    formulation->RegisterCurrentDensityAux(getParam<std::string>("current_density_name"));
   if (isParamValid("magnetic_flux_density_name"))
-    formulation.RegisterMagneticFluxDensityAux(getParam<std::string>("magnetic_flux_density_name"));
+    formulation->RegisterMagneticFluxDensityAux(
+        getParam<std::string>("magnetic_flux_density_name"));
   if (isParamValid("electric_field_name"))
-    formulation.RegisterElectricFieldAux(getParam<std::string>("electric_field_name"));
+    formulation->RegisterElectricFieldAux(getParam<std::string>("electric_field_name"));
   if (isParamValid("lorentz_force_density_name"))
-    formulation.RegisterLorentzForceDensityAux(getParam<std::string>("lorentz_force_density_name"),
-                                               getParam<std::string>("magnetic_flux_density_name"),
-                                               getParam<std::string>("current_density_name"));
+    formulation->RegisterLorentzForceDensityAux(getParam<std::string>("lorentz_force_density_name"),
+                                                getParam<std::string>("magnetic_flux_density_name"),
+                                                getParam<std::string>("current_density_name"));
   if (isParamValid("joule_heating_density_name"))
-    formulation.RegisterJouleHeatingDensityAux(getParam<std::string>("joule_heating_density_name"),
-                                               getParam<std::string>("electric_field_name"),
-                                               electric_conductivity_name);
+    formulation->RegisterJouleHeatingDensityAux(getParam<std::string>("joule_heating_density_name"),
+                                                getParam<std::string>("electric_field_name"),
+                                                electric_conductivity_name);
 }
 
 HFormulation::~HFormulation() {}

--- a/src/formulations/MagnetostaticFormulation.C
+++ b/src/formulations/MagnetostaticFormulation.C
@@ -31,18 +31,20 @@ MagnetostaticFormulation::MagnetostaticFormulation(const InputParameters & param
   : MFEMFormulation(parameters),
     magnetic_vector_potential_name(getParam<std::string>("magnetic_vector_potential_name")),
     magnetic_permeability_name(getParam<std::string>("magnetic_permeability_name")),
-    magnetic_reluctivity_name(getParam<std::string>("magnetic_reluctivity_name")),
-    formulation(
-        magnetic_reluctivity_name, magnetic_permeability_name, magnetic_vector_potential_name)
+    magnetic_reluctivity_name(getParam<std::string>("magnetic_reluctivity_name"))
 {
+  formulation = std::make_shared<hephaestus::MagnetostaticFormulation>(
+      magnetic_reluctivity_name, magnetic_permeability_name, magnetic_vector_potential_name);
+
   if (isParamValid("magnetic_flux_density_name"))
-    formulation.RegisterMagneticFluxDensityAux(getParam<std::string>("magnetic_flux_density_name"));
+    formulation->RegisterMagneticFluxDensityAux(
+        getParam<std::string>("magnetic_flux_density_name"));
   if (isParamValid("magnetic_field_name"))
-    formulation.RegisterMagneticFieldAux(getParam<std::string>("magnetic_field_name"));
+    formulation->RegisterMagneticFieldAux(getParam<std::string>("magnetic_field_name"));
   if (isParamValid("lorentz_force_density_name"))
-    formulation.RegisterLorentzForceDensityAux(getParam<std::string>("lorentz_force_density_name"),
-                                               getParam<std::string>("magnetic_flux_density_name"),
-                                               getParam<std::string>("current_density_name"));
+    formulation->RegisterLorentzForceDensityAux(getParam<std::string>("lorentz_force_density_name"),
+                                                getParam<std::string>("magnetic_flux_density_name"),
+                                                getParam<std::string>("current_density_name"));
 }
 
 MagnetostaticFormulation::~MagnetostaticFormulation() {}

--- a/src/formulations/MagnetostaticFormulation.C
+++ b/src/formulations/MagnetostaticFormulation.C
@@ -36,11 +36,11 @@ MagnetostaticFormulation::MagnetostaticFormulation(const InputParameters & param
         magnetic_reluctivity_name, magnetic_permeability_name, magnetic_vector_potential_name)
 {
   if (isParamValid("magnetic_flux_density_name"))
-    formulation.registerMagneticFluxDensityAux(getParam<std::string>("magnetic_flux_density_name"));
+    formulation.RegisterMagneticFluxDensityAux(getParam<std::string>("magnetic_flux_density_name"));
   if (isParamValid("magnetic_field_name"))
-    formulation.registerMagneticFieldAux(getParam<std::string>("magnetic_field_name"));
+    formulation.RegisterMagneticFieldAux(getParam<std::string>("magnetic_field_name"));
   if (isParamValid("lorentz_force_density_name"))
-    formulation.registerLorentzForceDensityAux(getParam<std::string>("lorentz_force_density_name"),
+    formulation.RegisterLorentzForceDensityAux(getParam<std::string>("lorentz_force_density_name"),
                                                getParam<std::string>("magnetic_flux_density_name"),
                                                getParam<std::string>("current_density_name"));
 }

--- a/src/kernels/MFEMDiffusionKernel.C
+++ b/src/kernels/MFEMDiffusionKernel.C
@@ -20,12 +20,6 @@ MFEMDiffusionKernel::MFEMDiffusionKernel(const InputParameters & parameters)
   : MFEMBilinearFormKernel(parameters),
     _kernel_params{{{"VariableName", getParam<std::string>("variable")},
                     {"CoefficientName", getParam<std::string>("coefficient")}}},
-    _kernel{std::make_unique<hephaestus::DiffusionKernel>(_kernel_params)}
+    _kernel{std::make_shared<hephaestus::DiffusionKernel>(_kernel_params)}
 {
-}
-
-hephaestus::Kernel<mfem::ParBilinearForm> *
-MFEMDiffusionKernel::getKernel()
-{
-  return _kernel.release(); // Caller assumes ownership.
 }

--- a/src/materials/MFEMConductor.C
+++ b/src/materials/MFEMConductor.C
@@ -38,15 +38,15 @@ MFEMConductor::MFEMConductor(const InputParameters & parameters)
 void
 MFEMConductor::storeCoefficients(hephaestus::Subdomain & subdomain)
 {
-  subdomain.scalar_coefficients.Register(
+  subdomain._scalar_coefficients.Register(
       "electrical_conductivity",
       const_cast<MFEMCoefficient *>(_electrical_conductivity_coeff)->getCoefficient(),
       false);
-  subdomain.scalar_coefficients.Register(
+  subdomain._scalar_coefficients.Register(
       "magnetic_permeability",
       const_cast<MFEMCoefficient *>(_permeability_coeff)->getCoefficient(),
       false);
-  subdomain.scalar_coefficients.Register(
+  subdomain._scalar_coefficients.Register(
       "dielectric_permittivity",
       const_cast<MFEMCoefficient *>(_permittivity_coeff)->getCoefficient(),
       false);

--- a/src/materials/MFEMThermalMaterial.C
+++ b/src/materials/MFEMThermalMaterial.C
@@ -28,11 +28,11 @@ MFEMThermalMaterial::MFEMThermalMaterial(const InputParameters & parameters)
 void
 MFEMThermalMaterial::storeCoefficients(hephaestus::Subdomain & subdomain)
 {
-  subdomain.scalar_coefficients.Register(
+  subdomain._scalar_coefficients.Register(
       "thermal_conductivity",
       const_cast<MFEMCoefficient *>(_thermal_conductivity_coeff)->getCoefficient(),
       false);
-  subdomain.scalar_coefficients.Register(
+  subdomain._scalar_coefficients.Register(
       "heat_capacity",
       const_cast<MFEMCoefficient *>(_heat_capacity_coeff)->getCoefficient(),
       false);

--- a/src/outputs/MFEMDataCollection.C
+++ b/src/outputs/MFEMDataCollection.C
@@ -13,3 +13,9 @@ MFEMDataCollection::validParams()
 MFEMDataCollection::MFEMDataCollection(const InputParameters & parameters) : FileOutput(parameters)
 {
 }
+
+std::shared_ptr<mfem::DataCollection>
+MFEMDataCollection::createDataCollection(const std::string & collection_name) const
+{
+  return std::make_shared<mfem::DataCollection>(collection_name);
+}

--- a/src/outputs/MFEMParaViewDataCollection.C
+++ b/src/outputs/MFEMParaViewDataCollection.C
@@ -28,13 +28,14 @@ MFEMParaViewDataCollection::MFEMParaViewDataCollection(const InputParameters & p
 {
 }
 
-mfem::ParaViewDataCollection *
-MFEMParaViewDataCollection::createDataCollection(const std::string & collection_name)
+std::shared_ptr<mfem::DataCollection>
+MFEMParaViewDataCollection::createDataCollection(const std::string & collection_name) const
 {
-  mfem::ParaViewDataCollection * pv_dc(
-      new mfem::ParaViewDataCollection(_file_base.c_str() + collection_name));
+  auto pv_dc = std::make_shared<mfem::ParaViewDataCollection>(_file_base.c_str() + collection_name);
+
   pv_dc->SetPrecision(9);
   pv_dc->SetHighOrderOutput(_high_order_output);
   pv_dc->SetLevelsOfDetail(_refinements + 1);
+
   return pv_dc;
 }

--- a/src/outputs/MFEMVisItDataCollection.C
+++ b/src/outputs/MFEMVisItDataCollection.C
@@ -20,11 +20,11 @@ MFEMVisItDataCollection::MFEMVisItDataCollection(const InputParameters & paramet
 {
 }
 
-mfem::VisItDataCollection *
-MFEMVisItDataCollection::createDataCollection(const std::string & collection_name)
+std::shared_ptr<mfem::DataCollection>
+MFEMVisItDataCollection::createDataCollection(const std::string & collection_name) const
 {
-  mfem::VisItDataCollection * visit_dc(
-      new mfem::VisItDataCollection(_file_base.c_str() + collection_name));
+  auto visit_dc = std::make_shared<mfem::VisItDataCollection>(_file_base.c_str() + collection_name);
   visit_dc->SetLevelsOfDetail(_refinements + 1);
+
   return visit_dc;
 }

--- a/src/problem/MFEMProblem.C
+++ b/src/problem/MFEMProblem.C
@@ -42,7 +42,7 @@ MFEMProblem::outputStep(ExecFlagType type)
       int filenum(dc->getFileNumber());
       std::string filename("/Run" + std::to_string(filenum));
 
-      mfem_problem->_outputs.Register(name, dc->createDataCollection(filename), true);
+      mfem_problem->_outputs.Register(name, dc->createDataCollection(filename));
       mfem_problem->_outputs.Reset();
       dc->setFileNumber(filenum + 1);
     }

--- a/src/problem/MFEMProblem.C
+++ b/src/problem/MFEMProblem.C
@@ -42,8 +42,8 @@ MFEMProblem::outputStep(ExecFlagType type)
       int filenum(dc->getFileNumber());
       std::string filename("/Run" + std::to_string(filenum));
 
-      mfem_problem->outputs.Register(name, dc->createDataCollection(filename), true);
-      mfem_problem->outputs.Reset();
+      mfem_problem->_outputs.Register(name, dc->createDataCollection(filename), true);
+      mfem_problem->_outputs.Reset();
       dc->setFileNumber(filenum + 1);
     }
   }
@@ -110,7 +110,7 @@ MFEMProblem::initialSetup()
   {
     mooseError("Executioner used that is not currently supported by MFEMProblem");
   }
-  mfem_problem->outputs.EnableGLVis(getParam<bool>("use_glvis"));
+  mfem_problem->_outputs.EnableGLVis(getParam<bool>("use_glvis"));
 }
 
 void
@@ -130,7 +130,7 @@ MFEMProblem::externalSolve()
   auto * transient_mfem_exec = dynamic_cast<hephaestus::TransientExecutioner *>(executioner.get());
   if (transient_mfem_exec != NULL)
   {
-    transient_mfem_exec->t_step = dt();
+    transient_mfem_exec->_t_step = dt();
   }
   executioner->Solve();
 }
@@ -155,7 +155,7 @@ MFEMProblem::addBoundaryCondition(const std::string & bc_name,
 {
   FEProblemBase::addUserObject(bc_name, name, parameters);
   MFEMBoundaryCondition * mfem_bc(&getUserObject<MFEMBoundaryCondition>(name));
-  mfem_problem_builder->AddBoundaryCondition(name, mfem_bc->getBC(), false);
+  mfem_problem_builder->AddBoundaryCondition(name, mfem_bc->getBC());
 }
 
 void
@@ -171,7 +171,7 @@ MFEMProblem::addMaterial(const std::string & kernel_name,
     int block = std::stoi(mfem_material.blocks[bid]);
     hephaestus::Subdomain mfem_subdomain(name, block);
     mfem_material.storeCoefficients(mfem_subdomain);
-    _coefficients.subdomains.push_back(mfem_subdomain);
+    _coefficients._subdomains.push_back(mfem_subdomain);
   }
 }
 
@@ -182,7 +182,7 @@ MFEMProblem::addSource(const std::string & user_object_name,
 {
   FEProblemBase::addUserObject(user_object_name, name, parameters);
   MFEMSource * mfem_source(&getUserObject<MFEMSource>(name));
-  mfem_problem_builder->AddSource(name, mfem_source->getSource(), true);
+  mfem_problem_builder->AddSource(name, mfem_source->getSource());
   mfem_source->storeCoefficients(_coefficients);
 }
 
@@ -193,11 +193,11 @@ MFEMProblem::addCoefficient(const std::string & user_object_name,
 {
   FEProblemBase::addUserObject(user_object_name, name, parameters);
   MFEMCoefficient * mfem_coef(&getUserObject<MFEMCoefficient>(name));
-  _coefficients.scalars.Register(name, mfem_coef->getCoefficient(), false);
+  _coefficients._scalars.Register(name, mfem_coef->getCoefficient(), false);
 
   // Add associated auxsolvers for CoupledCoefficients
   hephaestus::CoupledCoefficient * _coupled_coef =
-      dynamic_cast<hephaestus::CoupledCoefficient *>(_coefficients.scalars.Get(name));
+      dynamic_cast<hephaestus::CoupledCoefficient *>(_coefficients._scalars.Get(name));
   if (_coupled_coef != nullptr)
   {
     mfem_problem_builder->AddAuxSolver(name, _coupled_coef, false);
@@ -211,7 +211,7 @@ MFEMProblem::addVectorCoefficient(const std::string & user_object_name,
 {
   FEProblemBase::addUserObject(user_object_name, name, parameters);
   MFEMVectorCoefficient * mfem_vec_coef(&getUserObject<MFEMVectorCoefficient>(name));
-  _coefficients.vectors.Register(name, mfem_vec_coef->getVectorCoefficient(), false);
+  _coefficients._vectors.Register(name, mfem_vec_coef->getVectorCoefficient(), false);
 }
 
 void
@@ -286,7 +286,7 @@ MFEMProblem::addAuxKernel(const std::string & kernel_name,
     MFEMAuxSolver * mfem_auxsolver(&getUserObject<MFEMAuxSolver>(name));
 
     // NB: - set own_data = false to prevent double-free.
-    mfem_problem_builder->AddPostprocessor(name, mfem_auxsolver->getAuxSolver(), false);
+    mfem_problem_builder->AddPostprocessor(name, mfem_auxsolver->getAuxSolver());
     mfem_auxsolver->storeCoefficients(_coefficients);
   }
   else if (base_auxkernel == "AuxKernel" || base_auxkernel == "VectorAuxKernel" ||
@@ -333,7 +333,7 @@ MFEMProblem::setMFEMNodalVarData(MooseVariableFieldBase & moose_var_ref)
 
   auto & libmesh_base = mesh().getMesh();
   auto & temp_solution_vector = moose_var_ref.sys().solution();
-  auto & pgf = *(mfem_problem->gridfunctions.Get(moose_var_ref.name()));
+  auto & pgf = *(mfem_problem->_gridfunctions.Get(moose_var_ref.name()));
 
   const auto * par_fespace = order > 1 ? pgf.ParFESpace() : nullptr;
 
@@ -415,7 +415,7 @@ MFEMProblem::setMFEMElementalVarData(MooseVariableFieldBase & moose_var_ref)
 
   auto & libmesh_base = mesh().getMesh();
   auto & temp_solution_vector = moose_var_ref.sys().solution();
-  auto & pgf = *(mfem_problem->gridfunctions.Get(moose_var_ref.name()));
+  auto & pgf = *(mfem_problem->_gridfunctions.Get(moose_var_ref.name()));
 
   // Count number of true local dofs.
   unsigned int true_local_dofs_count = 0;
@@ -458,7 +458,7 @@ MFEMProblem::setMOOSENodalVarData(MooseVariableFieldBase & moose_var_ref)
   auto order = (unsigned int)moose_var_ref.order();
 
   auto & libmesh_base = mesh().getMesh();
-  auto & pgf = *(mfem_problem->gridfunctions.Get(moose_var_ref.name()));
+  auto & pgf = *(mfem_problem->_gridfunctions.Get(moose_var_ref.name()));
 
   const auto * par_fespace = (order > 1) ? pgf.ParFESpace() : nullptr;
 
@@ -518,7 +518,7 @@ MFEMProblem::setMOOSEElementalVarData(MooseVariableFieldBase & moose_var_ref)
               "Currently, only constant-order elemental variables can be synced in parallel.");
 
   auto & libmesh_base = mesh().getMesh();
-  auto & pgf = *(mfem_problem->gridfunctions.Get(moose_var_ref.name()));
+  auto & pgf = *(mfem_problem->_gridfunctions.Get(moose_var_ref.name()));
 
   auto * mfem_local_elems = pgf.GetTrueDofs(); // Must delete.
 

--- a/src/problem/MFEMProblem.C
+++ b/src/problem/MFEMProblem.C
@@ -82,34 +82,45 @@ MFEMProblem::initialSetup()
   Transient * _moose_executioner = dynamic_cast<Transient *>(_app.getExecutioner());
   if (_moose_executioner != nullptr)
   {
-    auto * mfem_transient_problem_builder =
-        dynamic_cast<hephaestus::TimeDomainProblemBuilder *>(mfem_problem_builder);
+    auto mfem_transient_problem_builder =
+        std::dynamic_pointer_cast<hephaestus::TimeDomainProblemBuilder>(mfem_problem_builder);
     if (mfem_transient_problem_builder == nullptr)
+    {
       mooseError("Specified formulation does not support Transient executioners");
+    }
+
     mfem_problem = mfem_transient_problem_builder->ReturnProblem();
+
     exec_params.SetParam("StartTime", float(_moose_executioner->getStartTime()));
     exec_params.SetParam("TimeStep", float(dt()));
     exec_params.SetParam("EndTime", float(_moose_executioner->endTime()));
     exec_params.SetParam("VisualisationSteps", getParam<int>("vis_steps"));
     exec_params.SetParam("Problem",
                          dynamic_cast<hephaestus::TimeDomainProblem *>(mfem_problem.get()));
+
     executioner = std::make_unique<hephaestus::TransientExecutioner>(exec_params);
   }
   else if (dynamic_cast<Steady *>(_app.getExecutioner()))
   {
-    auto * mfem_steady_problem_builder =
-        dynamic_cast<hephaestus::SteadyStateProblemBuilder *>(mfem_problem_builder);
+    auto mfem_steady_problem_builder =
+        std::dynamic_pointer_cast<hephaestus::SteadyStateProblemBuilder>(mfem_problem_builder);
     if (mfem_steady_problem_builder == nullptr)
+    {
       mooseError("Specified formulation does not support Steady executioners");
+    }
+
     mfem_problem = mfem_steady_problem_builder->ReturnProblem();
+
     exec_params.SetParam("Problem",
                          dynamic_cast<hephaestus::SteadyStateProblem *>(mfem_problem.get()));
+
     executioner = std::make_unique<hephaestus::SteadyExecutioner>(exec_params);
   }
   else
   {
     mooseError("Executioner used that is not currently supported by MFEMProblem");
   }
+
   mfem_problem->_outputs.EnableGLVis(getParam<bool>("use_glvis"));
 }
 

--- a/src/sources/MFEMClosedCoilSource.C
+++ b/src/sources/MFEMClosedCoilSource.C
@@ -47,13 +47,8 @@ MFEMClosedCoilSource::MFEMClosedCoilSource(const InputParameters & parameters)
   {
     _coil_domains[bid] = blocks[bid];
   }
-  _source = new hephaestus::ClosedCoilSolver(_closed_coil_params, _coil_domains, _coil_xsection_id);
-}
 
-hephaestus::Source *
-MFEMClosedCoilSource::getSource()
-{
-  return _source;
+  _source = std::make_shared<hephaestus::ClosedCoilSolver>(_closed_coil_params, _coil_domains, _coil_xsection_id);
 }
 
 void

--- a/src/sources/MFEMClosedCoilSource.C
+++ b/src/sources/MFEMClosedCoilSource.C
@@ -48,12 +48,6 @@ MFEMClosedCoilSource::MFEMClosedCoilSource(const InputParameters & parameters)
     _coil_domains[bid] = blocks[bid];
   }
 
-  _source = std::make_shared<hephaestus::ClosedCoilSolver>(_closed_coil_params, _coil_domains, _coil_xsection_id);
+  _source = std::make_shared<hephaestus::ClosedCoilSolver>(
+      _closed_coil_params, _coil_domains, _coil_xsection_id);
 }
-
-void
-MFEMClosedCoilSource::storeCoefficients(hephaestus::Coefficients & coefficients)
-{
-}
-
-MFEMClosedCoilSource::~MFEMClosedCoilSource() {}

--- a/src/sources/MFEMDivFreeVolumetricSource.C
+++ b/src/sources/MFEMDivFreeVolumetricSource.C
@@ -69,7 +69,7 @@ MFEMDivFreeVolumetricSource::getSource()
 void
 MFEMDivFreeVolumetricSource::storeCoefficients(hephaestus::Coefficients & coefficients)
 {
-  coefficients.vectors.Register(source_coef_name, _restricted_coef, true);
+  coefficients._vectors.Register(source_coef_name, _restricted_coef, true);
 }
 
 MFEMDivFreeVolumetricSource::~MFEMDivFreeVolumetricSource() {}

--- a/src/sources/MFEMDivFreeVolumetricSource.C
+++ b/src/sources/MFEMDivFreeVolumetricSource.C
@@ -57,13 +57,7 @@ MFEMDivFreeVolumetricSource::MFEMDivFreeVolumetricSource(const InputParameters &
   div_free_source_params.SetParam("H1FESpaceName", h1_fespace.name());
   div_free_source_params.SetParam("SolverOptions", _solver_options);
 
-  _source = new hephaestus::DivFreeSource(div_free_source_params);
-}
-
-hephaestus::Source *
-MFEMDivFreeVolumetricSource::getSource()
-{
-  return _source;
+  _source = std::make_shared<hephaestus::DivFreeSource>(div_free_source_params);
 }
 
 void

--- a/src/sources/MFEMDivFreeVolumetricSource.C
+++ b/src/sources/MFEMDivFreeVolumetricSource.C
@@ -36,7 +36,8 @@ MFEMDivFreeVolumetricSource::MFEMDivFreeVolumetricSource(const InputParameters &
     sourcecoefs[i] = _vec_coef->getVectorCoefficient();
     coilsegments[i] = int(blocks[i]);
   }
-  _restricted_coef = new mfem::PWVectorCoefficient(3, coilsegments, sourcecoefs);
+
+  _restricted_coef = std::make_shared<mfem::PWVectorCoefficient>(3, coilsegments, sourcecoefs);
 
   hephaestus::InputParameters _solver_options;
   EquationSystems & es = getParam<FEProblemBase *>("_fe_problem_base")->es();
@@ -63,7 +64,7 @@ MFEMDivFreeVolumetricSource::MFEMDivFreeVolumetricSource(const InputParameters &
 void
 MFEMDivFreeVolumetricSource::storeCoefficients(hephaestus::Coefficients & coefficients)
 {
-  coefficients._vectors.Register(source_coef_name, _restricted_coef, true);
+  coefficients._vectors.Register(source_coef_name, _restricted_coef);
 }
 
 MFEMDivFreeVolumetricSource::~MFEMDivFreeVolumetricSource() {}

--- a/src/sources/MFEMDivFreeVolumetricSource.C
+++ b/src/sources/MFEMDivFreeVolumetricSource.C
@@ -7,7 +7,8 @@ MFEMDivFreeVolumetricSource::validParams()
 {
   InputParameters params = MFEMSource::validParams();
   params.addRequiredParam<UserObjectName>(
-      "vector_coefficient", "The vector MFEM coefficient providing the source to be divergence cleaned");  
+      "vector_coefficient",
+      "The vector MFEM coefficient providing the source to be divergence cleaned");
   params.addRequiredParam<UserObjectName>("hcurl_fespace",
                                           "The H(Curl) FE space to use in the source.");
   params.addRequiredParam<UserObjectName>("h1_fespace", "The H1 FE space to use in the source.");
@@ -66,5 +67,3 @@ MFEMDivFreeVolumetricSource::storeCoefficients(hephaestus::Coefficients & coeffi
 {
   coefficients._vectors.Register(source_coef_name, _restricted_coef);
 }
-
-MFEMDivFreeVolumetricSource::~MFEMDivFreeVolumetricSource() {}

--- a/src/sources/MFEMOpenCoilSource.C
+++ b/src/sources/MFEMOpenCoilSource.C
@@ -80,8 +80,3 @@ MFEMOpenCoilSource::MFEMOpenCoilSource(const InputParameters & parameters)
   _source =
       std::make_shared<hephaestus::OpenCoilSolver>(_open_coil_params, _coil_domains, _electrodes);
 }
-
-void
-MFEMOpenCoilSource::storeCoefficients(hephaestus::Coefficients & coefficients)
-{
-}

--- a/src/sources/MFEMOpenCoilSource.C
+++ b/src/sources/MFEMOpenCoilSource.C
@@ -76,13 +76,12 @@ MFEMOpenCoilSource::MFEMOpenCoilSource(const InputParameters & parameters)
   {
     _coil_domains[bid] = blocks[bid];
   }
-  
-  _source = std::make_shared<hephaestus::OpenCoilSolver>(_open_coil_params, _coil_domains, _electrodes);
+
+  _source =
+      std::make_shared<hephaestus::OpenCoilSolver>(_open_coil_params, _coil_domains, _electrodes);
 }
 
 void
 MFEMOpenCoilSource::storeCoefficients(hephaestus::Coefficients & coefficients)
 {
 }
-
-MFEMOpenCoilSource::~MFEMOpenCoilSource() {}

--- a/src/sources/MFEMOpenCoilSource.C
+++ b/src/sources/MFEMOpenCoilSource.C
@@ -76,13 +76,8 @@ MFEMOpenCoilSource::MFEMOpenCoilSource(const InputParameters & parameters)
   {
     _coil_domains[bid] = blocks[bid];
   }
-  _source = new hephaestus::OpenCoilSolver(_open_coil_params, _coil_domains, _electrodes);
-}
-
-hephaestus::Source *
-MFEMOpenCoilSource::getSource()
-{
-  return _source;
+  
+  _source = std::make_shared<hephaestus::OpenCoilSolver>(_open_coil_params, _coil_domains, _electrodes);
 }
 
 void

--- a/src/sources/MFEMScalarPotentialSource.C
+++ b/src/sources/MFEMScalarPotentialSource.C
@@ -59,10 +59,4 @@ MFEMScalarPotentialSource::MFEMScalarPotentialSource(const InputParameters & par
   _source = std::make_shared<hephaestus::ScalarPotentialSource>(scalar_potential_source_params);
 }
 
-void
-MFEMScalarPotentialSource::storeCoefficients(hephaestus::Coefficients & coefficients)
-{
-  // coefficients.vectors[source_coef_name] = _restricted_coef;
-}
-
 MFEMScalarPotentialSource::~MFEMScalarPotentialSource() {}

--- a/src/sources/MFEMScalarPotentialSource.C
+++ b/src/sources/MFEMScalarPotentialSource.C
@@ -56,13 +56,7 @@ MFEMScalarPotentialSource::MFEMScalarPotentialSource(const InputParameters & par
   scalar_potential_source_params.SetParam("H1FESpaceName", h1_fespace.name());
   scalar_potential_source_params.SetParam("SolverOptions", _solver_options);
 
-  _source = new hephaestus::ScalarPotentialSource(scalar_potential_source_params);
-}
-
-hephaestus::Source *
-MFEMScalarPotentialSource::getSource()
-{
-  return _source;
+  _source = std::make_shared<hephaestus::ScalarPotentialSource>(scalar_potential_source_params);
 }
 
 void

--- a/src/sources/MFEMScalarPotentialSource.C
+++ b/src/sources/MFEMScalarPotentialSource.C
@@ -58,5 +58,3 @@ MFEMScalarPotentialSource::MFEMScalarPotentialSource(const InputParameters & par
 
   _source = std::make_shared<hephaestus::ScalarPotentialSource>(scalar_potential_source_params);
 }
-
-MFEMScalarPotentialSource::~MFEMScalarPotentialSource() {}

--- a/src/sources/MFEMSource.C
+++ b/src/sources/MFEMSource.C
@@ -17,12 +17,6 @@ MFEMSource::MFEMSource(const InputParameters & parameters)
 {
 }
 
-hephaestus::Source *
-MFEMSource::getSource()
-{
-  return _source;
-}
-
 void
 MFEMSource::storeCoefficients(hephaestus::Coefficients & coefficients)
 {


### PR DESCRIPTION
**Brief**
The primary goal of this PR is to switch to shared pointers in Apollo. This will make memory management easier and more consistent.

**Changes**
- Update Hephaestus version. This required updating the names of Hephaestus member variables in Apollo.
- Switch to shared pointers in AuxSolvers, Kernels, BoundaryConditions and Formulations. Note that shared pointers will also be added for coefficients in a later PR.
- Removed empty methods.