### PR TITLE
Fix Incorrect Pointer Registration and Update Hephaestus to Leak Fixed Version

### DIFF
--- a/include/kernels/MFEMBilinearFormKernel.h
+++ b/include/kernels/MFEMBilinearFormKernel.h
@@ -10,7 +10,7 @@ public:
   static InputParameters validParams();
 
   MFEMBilinearFormKernel(const InputParameters & parameters);
-  virtual ~MFEMBilinearFormKernel();
+  virtual ~MFEMBilinearFormKernel() {}
 
   virtual void execute() override {}
   virtual void initialize() override {}

--- a/include/kernels/MFEMDiffusionKernel.h
+++ b/include/kernels/MFEMDiffusionKernel.h
@@ -1,7 +1,6 @@
 #pragma once
 #include "MFEMBilinearFormKernel.h"
 #include "kernels.hpp"
-#include "diffusion_kernel.hpp"
 
 class MFEMDiffusionKernel : public MFEMBilinearFormKernel
 {

--- a/include/kernels/MFEMDiffusionKernel.h
+++ b/include/kernels/MFEMDiffusionKernel.h
@@ -1,6 +1,7 @@
 #pragma once
 #include "MFEMBilinearFormKernel.h"
 #include "kernels.hpp"
+#include "diffusion_kernel.hpp"
 
 class MFEMDiffusionKernel : public MFEMBilinearFormKernel
 {
@@ -8,15 +9,16 @@ public:
   static InputParameters validParams();
 
   MFEMDiffusionKernel(const InputParameters & parameters);
-  virtual ~MFEMDiffusionKernel();
+  ~MFEMDiffusionKernel() override {}
 
   virtual void execute() override {}
   virtual void initialize() override {}
   virtual void finalize() override {}
 
-  virtual hephaestus::Kernel<mfem::ParBilinearForm> * getKernel() override;
+  // NB: unique pointer releases ownership when called. Caller is responsible for deleting kernel.
+  hephaestus::Kernel<mfem::ParBilinearForm> * getKernel() override;
 
 protected:
-  hephaestus::InputParameters kernel_params;
-  hephaestus::DiffusionKernel kernel;
+  hephaestus::InputParameters _kernel_params;
+  std::unique_ptr<hephaestus::DiffusionKernel> _kernel{nullptr};
 };

--- a/include/problem/MFEMProblem.h
+++ b/include/problem/MFEMProblem.h
@@ -163,5 +163,6 @@ protected:
   hephaestus::InputParameters _solver_options;
   hephaestus::Outputs _outputs;
   hephaestus::InputParameters _exec_params;
-  hephaestus::Executioner * executioner;
+
+  std::unique_ptr<hephaestus::Executioner> executioner;
 };

--- a/include/problem/MFEMProblem.h
+++ b/include/problem/MFEMProblem.h
@@ -157,12 +157,13 @@ protected:
   std::string _input_mesh;
   std::string _formulation_name;
   int _order;
-  hephaestus::ProblemBuilder * mfem_problem_builder;
-  std::unique_ptr<hephaestus::Problem> mfem_problem;
+
   hephaestus::Coefficients _coefficients;
   hephaestus::InputParameters _solver_options;
   hephaestus::Outputs _outputs;
   hephaestus::InputParameters _exec_params;
+  hephaestus::ProblemBuilder * mfem_problem_builder;
 
+  std::unique_ptr<hephaestus::Problem> mfem_problem;
   std::unique_ptr<hephaestus::Executioner> executioner;
 };

--- a/src/auxkernels/MFEMJouleHeatingAux.C
+++ b/src/auxkernels/MFEMJouleHeatingAux.C
@@ -29,7 +29,7 @@ void
 MFEMJouleHeatingAux::storeCoefficients(hephaestus::Coefficients & coefficients)
 {
   std::string coef_name = std::string("JouleHeating");
-  coefficients.scalars.Register(coef_name, &joule_heating_aux, true);
+  coefficients.scalars.Register(coef_name, &joule_heating_aux, false);
 }
 
 MFEMJouleHeatingAux::~MFEMJouleHeatingAux() {}

--- a/src/kernels/MFEMBilinearFormKernel.C
+++ b/src/kernels/MFEMBilinearFormKernel.C
@@ -17,5 +17,3 @@ MFEMBilinearFormKernel::MFEMBilinearFormKernel(const InputParameters & parameter
   : GeneralUserObject(parameters)
 {
 }
-
-MFEMBilinearFormKernel::~MFEMBilinearFormKernel() {}

--- a/src/kernels/MFEMDiffusionKernel.C
+++ b/src/kernels/MFEMDiffusionKernel.C
@@ -18,16 +18,14 @@ MFEMDiffusionKernel::validParams()
 
 MFEMDiffusionKernel::MFEMDiffusionKernel(const InputParameters & parameters)
   : MFEMBilinearFormKernel(parameters),
-    kernel_params({{"VariableName", getParam<std::string>("variable")},
-                   {"CoefficientName", getParam<std::string>("coefficient")}}),
-    kernel(kernel_params)
+    _kernel_params{{{"VariableName", getParam<std::string>("variable")},
+                    {"CoefficientName", getParam<std::string>("coefficient")}}},
+    _kernel{std::make_unique<hephaestus::DiffusionKernel>(_kernel_params)}
 {
 }
 
 hephaestus::Kernel<mfem::ParBilinearForm> *
 MFEMDiffusionKernel::getKernel()
 {
-  return &kernel;
+  return _kernel.release(); // Caller assumes ownership.
 }
-
-MFEMDiffusionKernel::~MFEMDiffusionKernel() {}

--- a/src/mesh/CoupledMFEMMesh.C
+++ b/src/mesh/CoupledMFEMMesh.C
@@ -87,8 +87,8 @@ CoupledMFEMMesh::buildBoundaryInfo(std::map<int, std::vector<int>> & element_ids
     auto element_ids = key_value_pair.second.element_ids;
     auto side_ids = key_value_pair.second.side_ids;
 
-    element_ids_for_boundary_id[boundary_id] = element_ids;
-    side_ids_for_boundary_id[boundary_id] = side_ids;
+    element_ids_for_boundary_id[boundary_id] = std::move(element_ids);
+    side_ids_for_boundary_id[boundary_id] = std::move(side_ids);
   }
 }
 
@@ -189,13 +189,13 @@ CoupledMFEMMesh::buildElementAndNodeIDs(const std::vector<int> & unique_block_id
         element_node_ids[node_counter] = element_ptr->node_id(node_counter);
       }
 
-      node_ids_for_element_id[element_id] = element_node_ids;
+      node_ids_for_element_id[element_id] = std::move(element_node_ids);
     }
 
     elements_in_block.shrink_to_fit();
 
     // Add to map.
-    element_ids_for_block_id[block_id] = elements_in_block;
+    element_ids_for_block_id[block_id] = std::move(elements_in_block);
   }
 }
 
@@ -275,7 +275,7 @@ CoupledMFEMMesh::buildMFEMMesh()
 
     std::array<double, 3> coordinates = {node(0), node(1), node(2)};
 
-    coordinates_for_node_id[node.id()] = coordinates;
+    coordinates_for_node_id[node.id()] = std::move(coordinates);
   }
 
   // 7.

--- a/src/mesh/CoupledMFEMMesh.C
+++ b/src/mesh/CoupledMFEMMesh.C
@@ -526,7 +526,7 @@ CoupledMFEMMesh::buildBoundaryNodeIDs(
 
   // Iterate over all boundary IDs.
   for (int boundary_id : unique_side_boundary_ids)
-  {
+  {    
     // Get element IDs of element on boundary (and their sides that are on boundary).
     auto & boundary_element_ids = element_ids_for_boundary_id.at(boundary_id);
     auto & boundary_element_sides = side_ids_for_boundary_id.at(boundary_id);
@@ -557,10 +557,10 @@ CoupledMFEMMesh::buildBoundaryNodeIDs(
       }
 
       // Add to vector.
-      boundary_node_ids[jelement] = nodes_of_element_on_side;
+      boundary_node_ids[jelement] = std::move(nodes_of_element_on_side);
     }
 
     // Add to the map.
-    node_ids_for_boundary_id[boundary_id] = boundary_node_ids;
+    node_ids_for_boundary_id[boundary_id] = std::move(boundary_node_ids);
   }
 }

--- a/src/mesh/CoupledMFEMMesh.C
+++ b/src/mesh/CoupledMFEMMesh.C
@@ -390,7 +390,7 @@ CoupledMFEMMesh::getBlockIDsForBoundaryID(
       block_ids[ielement++] = block_id_for_element_id.at(element_id);
     }
 
-    block_ids_for_boundary_id[boundary_id] = block_ids;
+    block_ids_for_boundary_id[boundary_id] = std::move(block_ids);
   }
 
   return block_ids_for_boundary_id;

--- a/src/problem/MFEMProblem.C
+++ b/src/problem/MFEMProblem.C
@@ -25,13 +25,7 @@ MFEMProblem::MFEMProblem(const InputParameters & params)
 {
 }
 
-MFEMProblem::~MFEMProblem()
-{
-  if (executioner != nullptr)
-  {
-    delete executioner;
-  }
-}
+MFEMProblem::~MFEMProblem() {}
 
 void
 MFEMProblem::outputStep(ExecFlagType type)
@@ -99,7 +93,7 @@ MFEMProblem::initialSetup()
     exec_params.SetParam("VisualisationSteps", getParam<int>("vis_steps"));
     exec_params.SetParam("Problem",
                          dynamic_cast<hephaestus::TimeDomainProblem *>(mfem_problem.get()));
-    executioner = new hephaestus::TransientExecutioner(exec_params);
+    executioner = std::make_unique<hephaestus::TransientExecutioner>(exec_params);
   }
   else if (dynamic_cast<Steady *>(_app.getExecutioner()))
   {
@@ -110,7 +104,7 @@ MFEMProblem::initialSetup()
     mfem_problem = mfem_steady_problem_builder->ReturnProblem();
     exec_params.SetParam("Problem",
                          dynamic_cast<hephaestus::SteadyStateProblem *>(mfem_problem.get()));
-    executioner = new hephaestus::SteadyExecutioner(exec_params);
+    executioner = std::make_unique<hephaestus::SteadyExecutioner>(exec_params);
   }
   else
   {
@@ -133,9 +127,8 @@ MFEMProblem::externalSolve()
     return;
   }
 
-  hephaestus::TransientExecutioner * transient_mfem_exec =
-      dynamic_cast<hephaestus::TransientExecutioner *>(executioner);
-  if (transient_mfem_exec != nullptr)
+  auto * transient_mfem_exec = dynamic_cast<hephaestus::TransientExecutioner *>(executioner.get());
+  if (transient_mfem_exec != NULL)
   {
     transient_mfem_exec->t_step = dt();
   }

--- a/src/problem/MFEMProblem.C
+++ b/src/problem/MFEMProblem.C
@@ -82,7 +82,7 @@ MFEMProblem::initialSetup()
   Transient * _moose_executioner = dynamic_cast<Transient *>(_app.getExecutioner());
   if (_moose_executioner != nullptr)
   {
-    hephaestus::TimeDomainProblemBuilder * mfem_transient_problem_builder =
+    auto * mfem_transient_problem_builder =
         dynamic_cast<hephaestus::TimeDomainProblemBuilder *>(mfem_problem_builder);
     if (mfem_transient_problem_builder == nullptr)
       mooseError("Specified formulation does not support Transient executioners");
@@ -97,7 +97,7 @@ MFEMProblem::initialSetup()
   }
   else if (dynamic_cast<Steady *>(_app.getExecutioner()))
   {
-    hephaestus::SteadyStateProblemBuilder * mfem_steady_problem_builder =
+    auto * mfem_steady_problem_builder =
         dynamic_cast<hephaestus::SteadyStateProblemBuilder *>(mfem_problem_builder);
     if (mfem_steady_problem_builder == nullptr)
       mooseError("Specified formulation does not support Steady executioners");
@@ -285,7 +285,8 @@ MFEMProblem::addAuxKernel(const std::string & kernel_name,
     FEProblemBase::addUserObject(kernel_name, name, parameters);
     MFEMAuxSolver * mfem_auxsolver(&getUserObject<MFEMAuxSolver>(name));
 
-    mfem_problem_builder->AddPostprocessor(name, mfem_auxsolver->getAuxSolver(), true);
+    // NB: - set own_data = false to prevent double-free.
+    mfem_problem_builder->AddPostprocessor(name, mfem_auxsolver->getAuxSolver(), false);
     mfem_auxsolver->storeCoefficients(_coefficients);
   }
   else if (base_auxkernel == "AuxKernel" || base_auxkernel == "VectorAuxKernel" ||

--- a/src/problem/MFEMProblem.C
+++ b/src/problem/MFEMProblem.C
@@ -458,7 +458,6 @@ MFEMProblem::setMOOSENodalVarData(MooseVariableFieldBase & moose_var_ref)
   auto order = (unsigned int)moose_var_ref.order();
 
   auto & libmesh_base = mesh().getMesh();
-  auto & temp_solution_vector = moose_var_ref.sys().solution();
   auto & pgf = *(mfem_problem->gridfunctions.Get(moose_var_ref.name()));
 
   const auto * par_fespace = (order > 1) ? pgf.ParFESpace() : nullptr;
@@ -519,7 +518,6 @@ MFEMProblem::setMOOSEElementalVarData(MooseVariableFieldBase & moose_var_ref)
               "Currently, only constant-order elemental variables can be synced in parallel.");
 
   auto & libmesh_base = mesh().getMesh();
-  auto & temp_solution_vector = moose_var_ref.sys().solution();
   auto & pgf = *(mfem_problem->gridfunctions.Get(moose_var_ref.name()));
 
   auto * mfem_local_elems = pgf.GetTrueDofs(); // Must delete.


### PR DESCRIPTION
**Changes**
- Fixed failing Apollo tests (double-free).
- Removed unused variables in MFEMProblem.
- Now using std::move in Apollo.
- Updated Hephaestus version to after memory leak initial fixes and before clang format changes.