### PR TITLE
Adds grad_potential to required prarameters for MFEMClosedCoilSource

### DIFF
--- a/examples/TEAM/Problem_7/team7_closed_coil_frequency_domain.i
+++ b/examples/TEAM/Problem_7/team7_closed_coil_frequency_domain.i
@@ -71,6 +71,10 @@
     type = MFEMVariable
     fespace = HCurlFESpace
   []
+  [source_grad_potential]
+    type = MFEMVariable
+    fespace = HCurlFESpace
+  []
 []
 
 [Sources]
@@ -78,6 +82,7 @@
     type = MFEMClosedCoilSource
     total_current_coefficient = CurrentCoef
     source_current_density_dual_gridfunction = source_current_density_dual
+    source_grad_potential = source_grad_potential
     hcurl_fespace = HCurlFESpace
     h1_fespace = H1FESpace
     coil_xsection_boundary = 7

--- a/examples/TEAM/Problem_7/team7_closed_coil_time_domain.i
+++ b/examples/TEAM/Problem_7/team7_closed_coil_time_domain.i
@@ -63,6 +63,10 @@
     type = MFEMVariable
     fespace = HCurlFESpace
   []
+  [source_grad_potential]
+    type = MFEMVariable
+    fespace = HCurlFESpace
+  []
 []
 
 [Sources]
@@ -70,6 +74,7 @@
     type = MFEMClosedCoilSource
     total_current_coefficient = CurrentCoef
     source_current_density_dual_gridfunction = source_current_density_dual
+    source_grad_potential = source_grad_potential
     hcurl_fespace = HCurlFESpace
     h1_fespace = H1FESpace
     coil_xsection_boundary = 7

--- a/include/sources/MFEMClosedCoilSource.h
+++ b/include/sources/MFEMClosedCoilSource.h
@@ -19,7 +19,10 @@ protected:
   const MFEMVariable & _source_current_density_dual_gridfunction;
   const MFEMFESpace & _hcurl_fespace;
   const MFEMFESpace & _h1_fespace;
+  const MFEMVariable & _source_grad_potential;
   const MFEMCoefficient & _total_current_coef;
+  const std::string _conductivity_coef_name;
+
   const hephaestus::InputParameters _closed_coil_params;
   mfem::Array<int> _coil_domains;
   const int _coil_xsection_id;

--- a/src/sources/MFEMClosedCoilSource.C
+++ b/src/sources/MFEMClosedCoilSource.C
@@ -22,6 +22,9 @@ MFEMClosedCoilSource::validParams()
   params.addParam<UserObjectName>("source_current_density_dual_gridfunction",
                                   "The gridfunction to store the source current density.");
 
+  params.addParam<UserObjectName>("source_grad_potential",
+                                  "The gridfunction to store the gradient of the potential.");
+
   params.addParam<BoundaryName>("coil_xsection_boundary",
                                 "A boundary (id or name) specifying a cross section of the coil in "
                                 "mesh, at which the current will be imposed");
@@ -34,11 +37,15 @@ MFEMClosedCoilSource::MFEMClosedCoilSource(const InputParameters & parameters)
         getUserObject<MFEMVariable>("source_current_density_dual_gridfunction")),
     _hcurl_fespace(getUserObject<MFEMFESpace>("hcurl_fespace")),
     _h1_fespace(getUserObject<MFEMFESpace>("h1_fespace")),
+    _source_grad_potential(getUserObject<MFEMVariable>("source_grad_potential")),
     _total_current_coef(getUserObject<MFEMCoefficient>("total_current_coefficient")),
+    _conductivity_coef_name(std::string("electrical_conductivity")),
     _closed_coil_params({{"JGridFunctionName", _source_current_density_dual_gridfunction.name()},
+                         {"GradPotentialName", _source_grad_potential.name()},
                          {"HCurlFESpaceName", _hcurl_fespace.name()},
                          {"H1FESpaceName", _h1_fespace.name()},
                          {"IFuncCoefName", _total_current_coef.name()},
+                         {"ConductivityCoefName", _conductivity_coef_name},
                          {"Jtransfer", true}}),
     _coil_domains(blocks.size()),
     _coil_xsection_id(std::stoi(getParam<BoundaryName>("coil_xsection_boundary")))


### PR DESCRIPTION
Fixes a bug in MFEMClosedCoilSource where a required parameter was not being passed to hephaestus::ClosedCoilSolver.