### PR TITLE
Hotfix for Apollo Build Issues using Latest MOOSE

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ CONTACT                     := no
 EXTERNAL_PETSC_SOLVER       := no
 FLUID_PROPERTIES            := no
 FUNCTIONAL_EXPANSION_TOOLS  := no
-HEAT_CONDUCTION             := yes
+HEAT_TRANSFER             	:= yes
 LEVEL_SET                   := no
 MISC                        := no
 NAVIER_STOKES               := no
@@ -61,7 +61,6 @@ BUILD_EXEC         := yes
 GEN_REVISION       := no
 DEP_APPS           := $(shell $(FRAMEWORK_DIR)/scripts/find_dep_apps.py $(APPLICATION_NAME))
 include            $(FRAMEWORK_DIR)/app.mk
-
 
 ###############################################################################
 # Additional special case targets should be added here

--- a/docker/apollo-deps/Dockerfile
+++ b/docker/apollo-deps/Dockerfile
@@ -11,9 +11,9 @@ ARG WORKDIR="opt"
 #Configure MOOSE
 RUN export MOOSE_JOBS="$compile_cores" && \
     cd /$WORKDIR && \
-    git clone https://github.com/idaholab/moose && \
+    git clone https://github.com/EdwardPalmer99/moose.git && \
     cd moose && \
-    git checkout master && \
+    git checkout EdwardPalmer99/Revert-Changes-To-Executable-Linking-App-MakeFile && \
     export PETSC_DIR=/$WORKDIR/petsc && \
     export PETSC_ARCH=arch-linux-c-opt && \
     export CC=mpicc && \


### PR DESCRIPTION
**Brief**
- Addresses issue #88 .
- All tests were failing because the shared library 'libhephaestus.so' could not be found. This was caused by a recent MOOSE update to app.mk.

**Changes**
- Updated Dockerfile to pull from forked MOOSE repository and checkout branch which reverts these changes.
