### PR TITLE
Use positive-definite Joule heating Auxsolver from Hephaestus

### DIFF
--- a/src/formulations/AFormulation.C
+++ b/src/formulations/AFormulation.C
@@ -103,8 +103,7 @@ AFormulation::AFormulation(const InputParameters & parameters)
     formulation->RegisterLorentzForceDensityAux(
         _lorentz_force_density_name, _magnetic_flux_density_name, _current_density_name);
   if (isParamValid("joule_heating_density_name"))
-    formulation->RegisterJouleHeatingDensityAux(
-        _joule_heating_density_name, _electric_field_name, _current_density_name);
+    formulation->RegisterJouleHeatingDensityAux(_joule_heating_density_name, _electric_field_name);
 }
 
 AFormulation::~AFormulation() {}

--- a/src/formulations/ComplexAFormulation.C
+++ b/src/formulations/ComplexAFormulation.C
@@ -85,9 +85,7 @@ ComplexAFormulation::ComplexAFormulation(const InputParameters & parameters)
   if (isParamValid("joule_heating_density_name"))
     formulation->RegisterJouleHeatingDensityAux(getParam<std::string>("joule_heating_density_name"),
                                                 getParam<std::string>("electric_field_re_name"),
-                                                getParam<std::string>("electric_field_im_name"),
-                                                getParam<std::string>("current_density_re_name"),
-                                                getParam<std::string>("current_density_im_name"));
+                                                getParam<std::string>("electric_field_im_name"));
 }
 
 ComplexAFormulation::~ComplexAFormulation() {}

--- a/src/formulations/ComplexEFormulation.C
+++ b/src/formulations/ComplexEFormulation.C
@@ -74,9 +74,7 @@ ComplexEFormulation::ComplexEFormulation(const InputParameters & parameters)
   if (isParamValid("joule_heating_density_name"))
     formulation->RegisterJouleHeatingDensityAux(getParam<std::string>("joule_heating_density_name"),
                                                 getParam<std::string>("e_field_re_name"),
-                                                getParam<std::string>("e_field_im_name"),
-                                                getParam<std::string>("current_density_re_name"),
-                                                getParam<std::string>("current_density_im_name"));
+                                                getParam<std::string>("e_field_im_name"));
 }
 
 ComplexEFormulation::~ComplexEFormulation() {}

--- a/src/formulations/EBFormulation.C
+++ b/src/formulations/EBFormulation.C
@@ -65,8 +65,7 @@ EBFormulation::EBFormulation(const InputParameters & parameters)
     formulation->RegisterLorentzForceDensityAux(
         _lorentz_force_density_name, _magnetic_flux_density_name, _current_density_name);
   if (isParamValid("joule_heating_density_name"))
-    formulation->RegisterJouleHeatingDensityAux(
-        _joule_heating_density_name, _electric_field_name, _current_density_name);
+    formulation->RegisterJouleHeatingDensityAux(_joule_heating_density_name, _electric_field_name);
 }
 
 EBFormulation::~EBFormulation() {}

--- a/src/formulations/EFormulation.C
+++ b/src/formulations/EFormulation.C
@@ -52,8 +52,7 @@ EFormulation::EFormulation(const InputParameters & parameters)
     formulation->RegisterCurrentDensityAux(_current_density_name, _external_current_density_name);
 
   if (isParamValid("joule_heating_density_name"))
-    formulation->RegisterJouleHeatingDensityAux(
-        _joule_heating_density_name, _electric_field_name, _current_density_name);
+    formulation->RegisterJouleHeatingDensityAux(_joule_heating_density_name, _electric_field_name);
 }
 
 EFormulation::~EFormulation() {}

--- a/src/formulations/HFormulation.C
+++ b/src/formulations/HFormulation.C
@@ -97,8 +97,7 @@ HFormulation::HFormulation(const InputParameters & parameters)
     formulation->RegisterLorentzForceDensityAux(
         _lorentz_force_density_name, _magnetic_flux_density_name, _current_density_name);
   if (isParamValid("joule_heating_density_name"))
-    formulation->RegisterJouleHeatingDensityAux(
-        _joule_heating_density_name, _electric_field_name, _current_density_name);
+    formulation->RegisterJouleHeatingDensityAux(_joule_heating_density_name, _electric_field_name);
 }
 
 HFormulation::~HFormulation() {}


### PR DESCRIPTION
Due to interpolation, Joule heating calculated from discrete representations of E and J was not always positive definite for some systems, which could lead to some coupled thermal solves to struggle. This updates the default Joule heating Auxsolver chosen for Hephaestus formulations to use a positive definite alternative instead