### PR TITLE
Fix ClosedCoilSolver PWCoefficient bug and add logger for Hephaestus

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,8 +37,8 @@ This step is not needed if using the supplied alexanderianblair/apollo container
 cd /opt/apollo/contrib/hephaestus/
 mkdir build
 cd build
-cmake -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=Release -DMFEM_DIR=/opt/mfem/build -DMFEM_COMMON_INCLUDES=/opt/mfem/miniapps/common  ..
-make
+cmake -G Ninja -DCMAKE_BUILD_TYPE=Release -DMFEM_DIR=/opt/mfem/build ..
+ninja
 ```
 
 Apollo can then be built with the following commands from the top level `apollo` directory in either of the above containers:

--- a/contrib/hephaestus.mk
+++ b/contrib/hephaestus.mk
@@ -1,15 +1,11 @@
 ############################### HEPHAESTUS ######################################
 #################################################################################
 MFEM_DIR				:=$(APPLICATION_DIR)/../mfem/build
-HYPRE_DIR				:=$(APPLICATION_DIR)/../hypre-2.28.0/src/
 HEPHAESTUS_DIR 			:=$(APPLICATION_DIR)/contrib/hephaestus
 
 include $(MFEM_DIR)/config/config.mk
-MFEM_INCLUDE 			:= -I$(MFEM_DIR) -I$(MFEM_SOURCE_DIR) -I$(MFEM_SOURCE_DIR)/miniapps/common
-MFEM_LIB 				:= $(MFEM_DIR) -L$(MFEM_DIR) -lmfem -lrt $(MFEM_DIR)/miniapps/common/ -L$(MFEM_DIR)/miniapps/common -lmfem-common
-
-HYPRE_INCLUDE 			:= -I$(HYPRE_DIR)
-HYPRE_LIB 				:= -L$(HYPRE_DIR)/lib/ -lHYPRE
+MFEM_INCLUDES 			:= -I$(MFEM_INC_DIR)/config -I$(MFEM_DIR)/ -I$(MFEM_DIR)/../miniapps/common
+MFEM_LIBS 				:= -L$(MFEM_DIR) -lmfem -lrt -L$(MFEM_DIR)/miniapps/common -lmfem-common $(MFEM_LIB)
 
 HEPHAESTUS_LIB_DIR		:= $(HEPHAESTUS_DIR)/lib
 HEPHAESTUS_LIB 			:= $(HEPHAESTUS_LIB_DIR)/libhephaestus.so
@@ -17,8 +13,8 @@ HEPHAESTUS_LIB 			:= $(HEPHAESTUS_LIB_DIR)/libhephaestus.so
 HEPHAESTUS_INCLUDE_LIB	:= $(sort $(dir $(shell find $(HEPHAESTUS_DIR)/src/ -name "*.hpp")))
 HEPHAESTUS_INCLUDE		:= $(foreach d, $(HEPHAESTUS_INCLUDE_LIB), -I$d) -I$(APPLICATION_DIR)/contrib/hephaestus/build/_deps/spdlog-src/include/
 
-HEPHAESTUS_CXX_FLAGS 	:= -Wall $(HEPHAESTUS_INCLUDE) $(MFEM_INCLUDE) -I$(MFEM_INC_DIR)/config $(HYPRE_INCLUDE)
-HEPHAESTUS_LDFLAGS		:= -Wl,-rpath,$(HEPHAESTUS_LIB_DIR) -L$(HEPHAESTUS_LIB_DIR) -lhephaestus $(MFEM_LIB) ${HYPRE_LIB} -L$(APPLICATION_DIR)/contrib/hephaestus/build/_deps/spdlog-build/ -lspdlogd
+HEPHAESTUS_CXX_FLAGS 	:= -Wall $(HEPHAESTUS_INCLUDE) $(MFEM_INCLUDES) -I$(MFEM_INC_DIR)/config
+HEPHAESTUS_LDFLAGS		:= -Wl,-rpath,$(HEPHAESTUS_LIB_DIR) -L$(HEPHAESTUS_LIB_DIR) -lhephaestus $(MFEM_LIBS) -L$(APPLICATION_DIR)/contrib/hephaestus/build/_deps/spdlog-build/ -lspdlogd
 
 libmesh_CXXFlags 		+= $(HEPHAESTUS_CXX_FLAGS)
 libmesh_LDFLAGS 		+= $(HEPHAESTUS_LDFLAGS)

--- a/contrib/hephaestus.mk
+++ b/contrib/hephaestus.mk
@@ -1,22 +1,24 @@
 ############################### HEPHAESTUS ######################################
 #################################################################################
 MFEM_DIR				:=$(APPLICATION_DIR)/../mfem/build
+HYPRE_DIR				:=$(APPLICATION_DIR)/../hypre-2.28.0/src/
+HEPHAESTUS_DIR 			:=$(APPLICATION_DIR)/contrib/hephaestus
 
 include $(MFEM_DIR)/config/config.mk
-
 MFEM_INCLUDE 			:= -I$(MFEM_DIR) -I$(MFEM_SOURCE_DIR) -I$(MFEM_SOURCE_DIR)/miniapps/common
-MFEM_LIB 				:= -L$(MFEM_DIR) -lmfem -lrt -L$(MFEM_DIR)/miniapps/common -lmfem-common
+MFEM_LIB 				:= $(MFEM_DIR) -L$(MFEM_DIR) -lmfem -lrt $(MFEM_DIR)/miniapps/common/ -L$(MFEM_DIR)/miniapps/common -lmfem-common
 
-HEPHAESTUS_DIR 			:= $(APPLICATION_DIR)/contrib/hephaestus
+HYPRE_INCLUDE 			:= -I$(HYPRE_DIR)
+HYPRE_LIB 				:= -L$(HYPRE_DIR)/lib/ -lHYPRE
 
 HEPHAESTUS_LIB_DIR		:= $(HEPHAESTUS_DIR)/lib
-HEPHAESTUS_LIB 			:= $(HEPHAESTUS_LIB_DIR)/libhephaestus.so 
+HEPHAESTUS_LIB 			:= $(HEPHAESTUS_LIB_DIR)/libhephaestus.so
 
 HEPHAESTUS_INCLUDE_LIB	:= $(sort $(dir $(shell find $(HEPHAESTUS_DIR)/src/ -name "*.hpp")))
-HEPHAESTUS_INCLUDE		:= $(foreach d, $(HEPHAESTUS_INCLUDE_LIB), -I$d)
+HEPHAESTUS_INCLUDE		:= $(foreach d, $(HEPHAESTUS_INCLUDE_LIB), -I$d) -I$(APPLICATION_DIR)/contrib/hephaestus/build/_deps/spdlog-src/include/
 
-HEPHAESTUS_CXX_FLAGS 	:= -Wall $(HEPHAESTUS_INCLUDE) $(MFEM_INCLUDE) -I$(MFEM_INC_DIR)/config
-HEPHAESTUS_LDFLAGS		:= -Wl,-rpath,$(HEPHAESTUS_LIB_DIR) -L$(HEPHAESTUS_LIB_DIR) -lhephaestus $(MFEM_LIB)
+HEPHAESTUS_CXX_FLAGS 	:= -Wall $(HEPHAESTUS_INCLUDE) $(MFEM_INCLUDE) -I$(MFEM_INC_DIR)/config $(HYPRE_INCLUDE)
+HEPHAESTUS_LDFLAGS		:= -Wl,-rpath,$(HEPHAESTUS_LIB_DIR) -L$(HEPHAESTUS_LIB_DIR) -lhephaestus $(MFEM_LIB) ${HYPRE_LIB} -L$(APPLICATION_DIR)/contrib/hephaestus/build/_deps/spdlog-build/ -lspdlogd
 
 libmesh_CXXFlags 		+= $(HEPHAESTUS_CXX_FLAGS)
 libmesh_LDFLAGS 		+= $(HEPHAESTUS_LDFLAGS)

--- a/contrib/hephaestus.mk
+++ b/contrib/hephaestus.mk
@@ -7,14 +7,16 @@ include $(MFEM_DIR)/config/config.mk
 MFEM_INCLUDES 			:= -I$(MFEM_INC_DIR)/config -I$(MFEM_DIR)/ -I$(MFEM_DIR)/../miniapps/common
 MFEM_LIBS 				:= -L$(MFEM_DIR) -lmfem -lrt -L$(MFEM_DIR)/miniapps/common -lmfem-common $(MFEM_LIB)
 
-HEPHAESTUS_LIB_DIR		:= $(HEPHAESTUS_DIR)/lib
-HEPHAESTUS_LIB 			:= $(HEPHAESTUS_LIB_DIR)/libhephaestus.so
+HEPHAESTUS_LIB		:= $(HEPHAESTUS_DIR)/lib
+
+SPDLOG_LIB 			:=$(HEPHAESTUS_DIR)/build/_deps/spdlog-build/
+SPDLOG_INCLUDE 		:=$(HEPHAESTUS_DIR)/build/_deps/spdlog-src/include/
 
 HEPHAESTUS_INCLUDE_LIB	:= $(sort $(dir $(shell find $(HEPHAESTUS_DIR)/src/ -name "*.hpp")))
-HEPHAESTUS_INCLUDE		:= $(foreach d, $(HEPHAESTUS_INCLUDE_LIB), -I$d) -I$(APPLICATION_DIR)/contrib/hephaestus/build/_deps/spdlog-src/include/
+HEPHAESTUS_INCLUDE		:= $(foreach d, $(HEPHAESTUS_INCLUDE_LIB), -I$d) -I$(SPDLOG_INCLUDE)
 
 HEPHAESTUS_CXX_FLAGS 	:= -Wall $(HEPHAESTUS_INCLUDE) $(MFEM_INCLUDES) -I$(MFEM_INC_DIR)/config
-HEPHAESTUS_LDFLAGS		:= -Wl,-rpath,$(HEPHAESTUS_LIB_DIR) -L$(HEPHAESTUS_LIB_DIR) -lhephaestus $(MFEM_LIBS) -L$(APPLICATION_DIR)/contrib/hephaestus/build/_deps/spdlog-build/ -lspdlogd
+HEPHAESTUS_LDFLAGS		:= -Wl,-rpath,$(HEPHAESTUS_LIB) -L$(HEPHAESTUS_LIB) -lhephaestus $(MFEM_LIBS) -L$(SPDLOG_LIB) -lspdlog
 
 libmesh_CXXFlags 		+= $(HEPHAESTUS_CXX_FLAGS)
 libmesh_LDFLAGS 		+= $(HEPHAESTUS_LDFLAGS)

--- a/docker/apollo/Dockerfile
+++ b/docker/apollo/Dockerfile
@@ -23,12 +23,12 @@ RUN cd /$WORKDIR && \
 RUN cd /$WORKDIR/apollo/contrib/hephaestus/ && \
     mkdir build && \
     cd build && \
-    cmake -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=Release -DMFEM_DIR=/$WORKDIR/mfem/build -DMFEM_COMMON_INCLUDES=/$WORKDIR/mfem/miniapps/common  .. && \
-    make -j1
+    cmake -G Ninja -DCMAKE_BUILD_TYPE=Release -DMFEM_DIR=/$WORKDIR/mfem/build .. && \
+    ninja
 
 # Test Hephaestus
 RUN cd /$WORKDIR/apollo/contrib/hephaestus/build && \
-    make test
+    ninja test
 
 # Build Apollo
 RUN cd /$WORKDIR/apollo && \

--- a/src/problem/MFEMProblem.C
+++ b/src/problem/MFEMProblem.C
@@ -23,6 +23,7 @@ MFEMProblem::MFEMProblem(const InputParameters & params)
     _outputs(),
     _exec_params()
 {
+  hephaestus::logger.set_level(spdlog::level::info);
 }
 
 MFEMProblem::~MFEMProblem() {}
@@ -60,7 +61,6 @@ MFEMProblem::initialSetup()
                            float(es.parameters.get<Real>("linear solver absolute tolerance")));
   _solver_options.SetParam("MaxIter",
                            es.parameters.get<unsigned int>("linear solver maximum iterations"));
-  _solver_options.SetParam("PrintLevel", 2);
   _coefficients.AddGlobalCoefficientsFromSubdomains();
 
   mfem_problem_builder->SetCoefficients(_coefficients);


### PR DESCRIPTION
Updates Hephaestus version used in Apollo:

- Fixes bug where ClosedCoilSolver would give incorrect current density distributions when the conductivity of the coil was specified using a PWCoefficient
- Adds support for Hephaestus's new logger to output MFEM problem setup and solve information
- Updates CoefficientAux and VectorCoefficientAux derived objects, to set variables via conservative mappings from parent coefficients rather than pointwise evaluations by default