### PR TITLE
Add MFEMLineSampler as an auxsolver

### DIFF
--- a/examples/TEAM/Problem_7/team7_closed_coil_frequency_domain.i
+++ b/examples/TEAM/Problem_7/team7_closed_coil_frequency_domain.i
@@ -77,6 +77,18 @@
   []
 []
 
+[AuxKernels]
+  [LineSampler]
+    type = MFEMLineSamplerAux
+    filename = 'bfield.csv'
+    variable = magnetic_flux_density_real
+    num_points = 100
+    start_point = '0.09 0.072 0.034'
+    end_point = '0.1 0.072 0.034'
+    header = 't (s), x (m), y (m), z (m), B_x (T), B_y (T), B_z (T)'
+  []
+[]
+
 [Sources]
   [SourceCoil]
     type = MFEMClosedCoilSource

--- a/include/auxkernels/MFEMLineSamplerAux.h
+++ b/include/auxkernels/MFEMLineSamplerAux.h
@@ -1,0 +1,32 @@
+#pragma once
+
+#include "MFEMAuxSolver.h"
+#include "MFEMVariable.h"
+
+class MFEMLineSamplerAux : public MFEMAuxSolver
+{
+public:
+  static InputParameters validParams();
+
+  MFEMLineSamplerAux(const InputParameters & parameters);
+  virtual ~MFEMLineSamplerAux();
+
+  virtual void execute() override {}
+  virtual void initialize() override {}
+  virtual void finalize() override {}
+
+  inline std::shared_ptr<hephaestus::AuxSolver> getAuxSolver() const override
+  {
+    return _line_sampler_aux;
+  }
+
+protected:
+  const MFEMVariable & _mfem_variable;
+  const Point _start_point;
+  const Point _end_point;
+  mfem::Vector _start_vec;
+  mfem::Vector _end_vec;
+  unsigned int _num_points;
+
+  std::shared_ptr<hephaestus::LineSamplerAux> _line_sampler_aux{nullptr};
+};

--- a/include/mesh/ExclusiveMFEMMesh.h
+++ b/include/mesh/ExclusiveMFEMMesh.h
@@ -24,7 +24,7 @@
 #include "libmesh/numeric_vector.h"
 #include "libmesh/system.h"
 #include "libmesh/vtk_io.h"
-#include "mfem.hpp"
+#include "hephaestus.hpp"
 
 /**
  * ExclusiveMFEMMesh
@@ -92,4 +92,7 @@ protected:
    */
   std::shared_ptr<MFEMMesh> _mfem_mesh;
   std::shared_ptr<MFEMParMesh> _mfem_par_mesh;
+  mfem::H1_FECollection default_nodal_fecoll;
+  std::shared_ptr<mfem::ParFiniteElementSpace> default_nodal_fespace{nullptr};
+  // std::shared_ptr<mfem::ParFiniteElementSpace> default_nodal_fespace(pmesh.get(), &fecm, 3);
 };

--- a/src/auxkernels/MFEMLineSamplerAux.C
+++ b/src/auxkernels/MFEMLineSamplerAux.C
@@ -1,0 +1,39 @@
+#include "MFEMLineSamplerAux.h"
+
+registerMooseObject("ApolloApp", MFEMLineSamplerAux);
+
+InputParameters
+MFEMLineSamplerAux::validParams()
+{
+  InputParameters params = MFEMAuxSolver::validParams();
+  params.addRequiredParam<Point>("start_point", "The beginning of the line");
+  params.addRequiredParam<Point>("end_point", "The end of the line");
+  params.addRequiredParam<unsigned int>("num_points",
+                                        "The number of points to sample along the line");
+  params.addRequiredParam<UserObjectName>(
+      "variable", "The FESpace associated with the test variable the source will be applied to.");
+  params.addRequiredParam<std::string>("header", "Header for the output CSV.");
+  params.addRequiredParam<std::string>("filename", "Name of the output CSV.");
+  return params;
+}
+
+MFEMLineSamplerAux::MFEMLineSamplerAux(const InputParameters & parameters)
+  : MFEMAuxSolver(parameters),
+    _mfem_variable(getUserObject<MFEMVariable>("variable")),
+    _start_point(getParam<Point>("start_point")),
+    _end_point(getParam<Point>("end_point")),
+    _start_vec({_start_point(0), _start_point(1), _start_point(2)}),
+    _end_vec({_end_point(0), _end_point(1), _end_point(2)}),
+    _num_points(getParam<unsigned int>("num_points")),
+    _line_sampler_aux{
+        std::make_shared<hephaestus::LineSamplerAux>(_mfem_variable.name(),
+                                                     _start_vec,
+                                                     _end_vec,
+                                                     _num_points,
+                                                     getParam<std::string>("filename"),
+                                                     getParam<std::string>("header"))}
+{
+  _line_sampler_aux->SetPriority(10);
+}
+
+MFEMLineSamplerAux::~MFEMLineSamplerAux() {}

--- a/src/auxkernels/MFEMLineSamplerAux.C
+++ b/src/auxkernels/MFEMLineSamplerAux.C
@@ -33,7 +33,7 @@ MFEMLineSamplerAux::MFEMLineSamplerAux(const InputParameters & parameters)
                                                      getParam<std::string>("filename"),
                                                      getParam<std::string>("header"))}
 {
-  _line_sampler_aux->SetPriority(10);
+  _line_sampler_aux->SetPriority(99);
 }
 
 MFEMLineSamplerAux::~MFEMLineSamplerAux() {}

--- a/src/mesh/CoupledMFEMMesh.C
+++ b/src/mesh/CoupledMFEMMesh.C
@@ -438,6 +438,9 @@ CoupledMFEMMesh::buildMFEMParMesh()
   convertSerialDofMappingsToParallel(*_mfem_mesh.get(), *_mfem_par_mesh.get());
 
   _mfem_mesh.reset(); // Lower reference count of serial mesh since no longer needed.
+  default_nodal_fespace =
+      std::make_shared<mfem::ParFiniteElementSpace>(_mfem_par_mesh.get(), &default_nodal_fecoll, 3);
+  _mfem_par_mesh->SetNodalFESpace(default_nodal_fespace.get());  
 }
 
 void

--- a/src/mesh/ExclusiveMFEMMesh.C
+++ b/src/mesh/ExclusiveMFEMMesh.C
@@ -18,7 +18,10 @@ ExclusiveMFEMMesh::validParams()
   return params;
 }
 
-ExclusiveMFEMMesh::ExclusiveMFEMMesh(const InputParameters & parameters) : FileMesh(parameters) {}
+ExclusiveMFEMMesh::ExclusiveMFEMMesh(const InputParameters & parameters)
+  : FileMesh(parameters), default_nodal_fecoll(1, 3)
+{
+}
 
 ExclusiveMFEMMesh::~ExclusiveMFEMMesh() {}
 
@@ -62,6 +65,9 @@ ExclusiveMFEMMesh::buildMFEMParMesh()
 {
   _mfem_par_mesh = std::make_shared<MFEMParMesh>(MPI_COMM_WORLD, getMFEMMesh());
   _mfem_mesh.reset(); // Lower reference count of serial mesh since no longer needed.
+  default_nodal_fespace =
+      std::make_shared<mfem::ParFiniteElementSpace>(_mfem_par_mesh.get(), &default_nodal_fecoll, 3);
+  _mfem_par_mesh->SetNodalFESpace(default_nodal_fespace.get());
 }
 
 MFEMMesh &


### PR DESCRIPTION
Adds `MFEMLineSampler` as a gslib-based `AuxSolver` from Hephaestus for CSV field outputs.